### PR TITLE
[log] 그래프를 통한 드론 배터리 정보 시각화

### DIFF
--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -8,7 +8,7 @@ export default function LogPage() {
       <Sidebar />
       <div className="block">
         <MultipleAxesCharts />
-        <SynchronisedCharts numOfDatasets={4} />
+        {/* <SynchronisedCharts numOfDatasets={4} /> */}
       </div>
     </div>
   );

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -8,7 +8,7 @@ export default function LogPage() {
       <Sidebar />
       <div className="block">
         <MultipleAxesCharts />
-        {/* <SynchronisedCharts numOfDatasets={4} /> */}
+        <SynchronisedCharts numOfDatasets={4} />
       </div>
     </div>
   );

--- a/src/app/log/page.tsx
+++ b/src/app/log/page.tsx
@@ -7,6 +7,7 @@ export default function LogPage() {
     <div className="flex">
       <Sidebar />
       <div className="block">
+        <MultipleAxesCharts />
         <SynchronisedCharts numOfDatasets={4} />
       </div>
     </div>

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -6,16 +6,22 @@ import HighchartsReact from "highcharts-react-official";
 import useData from "@/store/useData";
 
 export default function BatteryStatusChart() {
-  const { telemetryData } = useData();
+  const { telemetryData, selectedOperationId, validOperationLabels } =
+    useData();
   const batteryData = telemetryData[147] || []; // msgId 147 (BATTERY_STATUS)
 
-  // 이벤트 발생 시간대, 배터리 온도, 전압, 배터리 잔량만 필터링
-  const filteredBatteryData = batteryData.map((data: any) => ({
-    timestamp: new Date(data.timestamp),
-    temperature: data.payload.temperature,
-    voltages: data.payload.voltages[0],
-    batteryRemaining: data.payload.batteryRemaining,
-  }));
+  // 선택된 운행의 배터리 정보만 필터링
+  const filteredBatteryData = batteryData
+    .filter((data: any) => selectedOperationId.includes(data.operation))
+    .map((data: any) => ({
+      operationLabel: validOperationLabels[data.operation],
+      timestamp: new Date(data.timestamp),
+      temperature: data.payload.temperature,
+      voltages: data.payload.voltages[0],
+      batteryRemaining: data.payload.batteryRemaining,
+    }));
+
+  console.log(selectedOperationId.map((id) => validOperationLabels[id]));
 
   const options = {
     chart: {

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -50,7 +50,7 @@ const BatteryStatusChart = () => {
             times[batterRemain],
             data.payload.batteryRemaining,
           ]),
-          tooltip: { valueSuffix: "%" },
+          tooltip: { valueSuffix: " %", xDateFormat: "%Y-%m-%d %H:%M:%S" },
         },
         {
           name: `온도 (${validOperationLabels[operationId]})`,
@@ -82,6 +82,15 @@ const BatteryStatusChart = () => {
     const filteredSeries = series
       .flat()
       .filter((s) => s.data && s.data.length > 0);
+
+    // 그래프 Y축에 사용할 각 데이터 최대, 최소 값
+    const tempData = filteredData.map((data) => data.payload.temperature);
+    const voltData = filteredData.map((data) => data.payload.voltages[0]);
+
+    const tempMax = Math.ceil(Math.max(...tempData));
+    const tempMin = Math.floor(Math.min(...tempData));
+    const voltMax = Math.ceil(Math.max(...voltData));
+    const voltMin = Math.floor(Math.min(...voltData));
 
     return {
       chart: {
@@ -147,7 +156,7 @@ const BatteryStatusChart = () => {
           },
         ],
         inputEnabled: true,
-        selected: 6,
+        selected: 8,
         inputDateFormat: "%Y-%m-%d %H:%M",
         inputEditDateFormat: "%Y-%m-%d %H:%M",
       },
@@ -168,11 +177,15 @@ const BatteryStatusChart = () => {
         {
           title: { text: "온도 (°C)" },
           labels: { format: "{value}°C" },
+          max: tempMax,
+          min: tempMin,
         },
         {
           title: { text: "전압 (V)" },
           labels: { format: "{value}V" },
           opposite: true,
+          max: voltMax,
+          min: voltMin,
         },
         {
           title: { text: "배터리 잔량 (%)" },

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -29,7 +29,7 @@ export default function BatteryStatusChart() {
       //   type: "xy",
       // },
       height: 400,
-      width: 800,
+      width: 1200,
     },
     title: {
       text: "드론 배터리 데이터",
@@ -102,44 +102,36 @@ export default function BatteryStatusChart() {
     //     "rgba(255,255,255,0.25)", // theme
     // },
 
-    // 하드코딩 데이터
+    // 하드코딩 데이터에서 전역 데이터로 변환
     series: [
       {
-        name: "Rainfall",
-        type: "column",
-        yAxis: 1,
-        data: [
-          49.9, 71.5, 106.4, 129.2, 144.0, 176.0, 135.6, 148.5, 216.4, 194.1,
-          95.6, 54.4,
-        ],
-        tooltip: {
-          valueSuffix: " mm",
-        },
-      },
-      {
-        name: "Sea-Level Pressure",
+        name: "배터리 전압",
         type: "spline",
         yAxis: 2,
-        data: [
-          1016, 1016, 1015.9, 1015.5, 1012.3, 1009.5, 1009.6, 1010.2, 1013.1,
-          1016.9, 1018.2, 1016.7,
-        ],
+        data: filteredBatteryData.map((data) => data.voltages),
         marker: {
           enabled: false,
         },
         dashStyle: "shortdot",
         tooltip: {
-          valueSuffix: " mb",
+          valueSuffix: " V",
         },
       },
       {
-        name: "Temperature",
+        name: "배터리 온도",
         type: "spline",
-        data: [
-          7.0, 6.9, 9.5, 14.5, 18.2, 21.5, 25.2, 26.5, 23.3, 18.3, 13.9, 9.6,
-        ],
+        data: filteredBatteryData.map((data) => data.temperature),
         tooltip: {
           valueSuffix: " °C",
+        },
+      },
+      {
+        name: "배터리 잔량",
+        type: "column",
+        yAxis: 1,
+        data: filteredBatteryData.map((data) => data.batteryRemaining),
+        tooltip: {
+          valueSuffix: " %",
         },
       },
     ],

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -14,7 +14,7 @@ export default function BatteryStatusChart() {
       temperature: data[0],
       voltages: data[1],
       batteryRemaining: data[2],
-      timestamp: new Date(data[3]),
+      timestamp: new Date(data[3]).getTime(),
     }),
   );
 
@@ -32,7 +32,14 @@ export default function BatteryStatusChart() {
 
     xAxis: [
       {
-        categories: [],
+        categories: batteryData.map((data) =>
+          new Date(data.timestamp).toLocaleTimeString("ko-KR", {
+            hour: "2-digit",
+            minute: "2-digit",
+            // second: "2-digit",
+            hour12: false,
+          }),
+        ),
         crosshair: true,
       },
     ],

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -35,6 +35,8 @@ const BatteryStatusChart = () => {
     selectedOperationId.includes(data.operation),
   );
 
+  const hasData = filteredData.length > 0;
+
   const createChartOptions = () => {
     const colorSchemes = {
       battery: ["#00ff00", "#33cc33", "#269926", "#1a661a"], // green
@@ -227,11 +229,15 @@ const BatteryStatusChart = () => {
 
   return (
     <div>
-      <HighchartsReact
-        ref={chartComponentRef}
-        highcharts={Highcharts}
-        options={createChartOptions()}
-      />
+      {hasData ? (
+        <HighchartsReact
+          ref={chartComponentRef}
+          highcharts={Highcharts}
+          options={createChartOptions()}
+        />
+      ) : (
+        <p className="p-10 text-center text-gray-500">데이터가 없습니다.</p>
+      )}
     </div>
   );
 };

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -2,7 +2,13 @@
 import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
+import HighchartsStock from "highcharts/modules/stock";
 import useData from "@/store/useData";
+
+// Highcharts Stock 모듈 초기화
+if (typeof Highcharts === "object") {
+  HighchartsStock(Highcharts);
+}
 
 const BatteryStatusChart = () => {
   const { telemetryData, selectedOperationId, validOperationLabels } =
@@ -13,33 +19,15 @@ const BatteryStatusChart = () => {
     selectedOperationId.includes(data.operation),
   );
 
-  const groupByDate = () => {
-    const dateGroups = new Map();
-
-    filteredData.forEach((data) => {
-      const date = new Date(data.timestamp).toLocaleDateString();
-      if (!dateGroups.has(date)) {
-        dateGroups.set(date, []);
-      }
-      dateGroups.get(date).push(data);
-    });
-
-    return dateGroups;
-  };
-
-  const createChartOptions = (date: string, dateData: any[]) => {
+  const createChartOptions = () => {
     const colorSchemes = {
       battery: ["#00ff00", "#33cc33", "#269926", "#1a661a"], // green
       temperature: ["#ff6666", "#ff3333", "#ff0000", "#cc0000"], // red
       voltage: ["#3366ff", "#0044cc", "#003399", "#002266"], // blue
     };
 
-    const currentDateData = dateData.filter(
-      (data) => new Date(data.timestamp).toLocaleDateString() === date,
-    );
-
     const series = selectedOperationId.map((opId, index) => {
-      const operationData = currentDateData
+      const operationData = filteredData
         .filter((data) => data.operation === opId)
         .sort(
           (a, b) =>
@@ -89,11 +77,51 @@ const BatteryStatusChart = () => {
 
     return {
       chart: {
-        zooming: { type: "xy" },
-        height: 400,
+        height: 500,
         width: 1200,
       },
-      title: { text: `배터리 상태: ${date}` },
+      rangeSelector: {
+        enabled: true,
+        buttons: [
+          {
+            type: "minute",
+            count: 1,
+            text: "1분",
+          },
+          {
+            type: "minute",
+            count: 3,
+            text: "3분",
+          },
+          {
+            type: "hour",
+            count: 1,
+            text: "1시간",
+          },
+          {
+            type: "day",
+            count: 1,
+            text: "1일",
+          },
+          {
+            type: "week",
+            count: 1,
+            text: "1주",
+          },
+          {
+            type: "month",
+            count: 1,
+            text: "1개월",
+          },
+          {
+            type: "all",
+            text: "전체",
+          },
+        ],
+        inputEnabled: true,
+        selected: 3,
+      },
+      title: { text: "배터리 상태" },
       xAxis: {
         type: "datetime",
         crosshair: true,
@@ -143,17 +171,9 @@ const BatteryStatusChart = () => {
     };
   };
 
-  const dateGroups = groupByDate();
   return (
     <div>
-      {Array.from(dateGroups).map(([date, dateData]) => (
-        <div key={date}>
-          <HighchartsReact
-            highcharts={Highcharts}
-            options={createChartOptions(date, dateData)}
-          />
-        </div>
-      ))}
+      <HighchartsReact highcharts={Highcharts} options={createChartOptions()} />
     </div>
   );
 };

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -97,15 +97,15 @@ const BatteryStatusChart = () => {
         height: 600,
         width: 1200,
         zooming: {
-          enabled: true,
-          type: "x",
+          mouseWheel: {
+            enabled: true,
+            type: "x",
+          },
         },
         panning: {
           enabled: true,
           type: "x",
-          key: "shift",
         },
-        panKey: "shift",
       },
       rangeSelector: {
         enabled: true,
@@ -157,8 +157,8 @@ const BatteryStatusChart = () => {
         ],
         inputEnabled: true,
         selected: 8,
-        inputDateFormat: "%Y-%m-%d %H:%M",
-        inputEditDateFormat: "%Y-%m-%d %H:%M",
+        inputDateFormat: "%Y-%m-%d %H:%M:%S",
+        inputEditDateFormat: "%Y-%m-%d %H:%M:%S",
       },
       navigator: {
         enabled: true,
@@ -196,7 +196,7 @@ const BatteryStatusChart = () => {
         },
       ],
       tooltip: {
-        shared: false,
+        shared: true,
         crosshairs: true,
       },
       legend: {

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -86,11 +86,16 @@ const BatteryStatusChart = () => {
     // 그래프 Y축에 사용할 각 데이터 최대, 최소 값
     const tempData = filteredData.map((data) => data.payload.temperature);
     const voltData = filteredData.map((data) => data.payload.voltages[0]);
+    const batteryData = filteredData.map(
+      (data) => data.payload.batteryRemaining,
+    );
 
     const tempMax = Math.ceil(Math.max(...tempData));
     const tempMin = Math.floor(Math.min(...tempData));
     const voltMax = Math.ceil(Math.max(...voltData));
     const voltMin = Math.floor(Math.min(...voltData));
+    const batteryMax = Math.ceil(Math.max(...batteryData));
+    const batteryMin = Math.floor(Math.min(...batteryData));
 
     return {
       chart: {
@@ -190,8 +195,8 @@ const BatteryStatusChart = () => {
         {
           title: { text: "배터리 잔량 (%)" },
           labels: { format: "{value}%" },
-          max: 100,
-          min: 0,
+          max: batteryMax,
+          min: batteryMin,
           opposite: true,
         },
       ],

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -3,7 +3,20 @@ import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
-export default function DroneCharts() {
+import useData from "@/store/useData";
+
+export default function BatteryStatusChart() {
+  const { telemetryData } = useData();
+  const batteryData = telemetryData[147] || []; // msgId 147 (BATTERY_STATUS)
+
+  // 이벤트 발생 시간대, 배터리 온도, 전압, 배터리 잔량만 필터링
+  const filteredBatteryData = batteryData.map((data: any) => ({
+    timestamp: new Date(data.timestamp),
+    temperature: data.payload.temperature,
+    voltages: data.payload.voltages[0],
+    batteryRemaining: data.payload.batteryRemaining,
+  }));
+
   const options = {
     chart: {
       // zooming: {
@@ -13,11 +26,9 @@ export default function DroneCharts() {
       width: 800,
     },
     title: {
-      text: "Average Monthly Weather Data for Tokyo",
+      text: "드론 배터리 데이터",
     },
-    subtitle: {
-      text: "Source: WorldClimate.com",
-    },
+
     xAxis: [
       {
         categories: [],

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -1,61 +1,16 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 
-interface MultipleAxesChartsProps {
-  numOfDatasets?: number;
-  chartWidth?: number;
-  chartHeight?: number;
-}
-
-interface Dataset {
-  name: string;
-  type: string;
-  unit: string;
-  data: number[];
-}
-
-const WeatherChart: React.FC<MultipleAxesChartsProps> = ({
-  chartHeight = 400,
-  chartWidth = 800,
-}) => {
-  interface ChartData {
-    xData: number[];
-    datasets: Dataset[];
-  }
-
-  const [chartData, setChartData] = useState<ChartData | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await fetch("/activity.json");
-
-        if (!response.ok) {
-          throw new Error("Network response was not ok.");
-        }
-
-        const json = await response.json();
-        setChartData(json);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, []);
-
+export default function DroneCharts() {
   const options = {
     chart: {
-      zooming: {
-        type: "xy",
-      },
-      height: chartHeight,
-      width: chartWidth,
+      // zooming: {
+      //   type: "xy",
+      // },
+      height: 400,
+      width: 800,
     },
     title: {
       text: "Average Monthly Weather Data for Tokyo",
@@ -65,88 +20,72 @@ const WeatherChart: React.FC<MultipleAxesChartsProps> = ({
     },
     xAxis: [
       {
-        categories: [
-          "Jan",
-          "Feb",
-          "Mar",
-          "Apr",
-          "May",
-          "Jun",
-          "Jul",
-          "Aug",
-          "Sep",
-          "Oct",
-          "Nov",
-          "Dec",
-        ],
-        crosshair: true,
+        categories: [],
+        crosshair: true, //마우스 호버시 시각적 가이드 제공 기능
       },
     ],
     yAxis: [
       {
-        // Primary yAxis
         labels: {
-          format: "{value}°C",
-          style: {
-            color: Highcharts.getOptions().colors?.[2] ?? "#000000",
-          },
+          format: "{value}",
         },
         title: {
           text: "Temperature",
-          style: {
-            color: Highcharts.getOptions().colors?.[2] ?? "#000000",
-          },
         },
         opposite: true,
       },
       {
-        // Secondary yAxis
-        gridLineWidth: 0,
-        title: {
-          text: "Rainfall",
-          style: {
-            color: Highcharts.getOptions().colors?.[0] ?? "#000000",
-          },
-        },
-        labels: {
-          format: "{value} mm",
-          style: {
-            color: Highcharts.getOptions().colors?.[0] ?? "#000000",
-          },
-        },
+        // // Secondary yAxis
+        // gridLineWidth: 0,
+        // title: {
+        //   text: "Rainfall",
+        //   style: {
+        //     color: Highcharts.getOptions().colors?.[0] ?? "#000000",
+        //   },
+        // },
+        // labels: {
+        //   format: "{value} mm",
+        //   style: {
+        //     color: Highcharts.getOptions().colors?.[0] ?? "#000000",
+        //   },
+        // },
       },
       {
         // Tertiary yAxis
-        gridLineWidth: 0,
-        title: {
-          text: "Sea-Level Pressure",
-          style: {
-            color: Highcharts.getOptions().colors?.[1] ?? "#000000",
-          },
-        },
-        labels: {
-          format: "{value} mb",
-          style: {
-            color: Highcharts.getOptions().colors?.[1] ?? "#000000",
-          },
-        },
-        opposite: true,
+        // gridLineWidth: 0,
+        // title: {
+        //   text: "Sea-Level Pressure",
+        //   style: {
+        //     color: Highcharts.getOptions().colors?.[1] ?? "#000000",
+        //   },
+        // },
+        // labels: {
+        //   format: "{value} mb",
+        //   style: {
+        //     color: Highcharts.getOptions().colors?.[1] ?? "#000000",
+        //   },
+        // },
+        // opposite: true,
       },
     ],
-    tooltip: {
-      shared: true,
-    },
-    legend: {
-      layout: "vertical",
-      align: "left",
-      x: 80,
-      verticalAlign: "top",
-      y: 55,
-      floating: true,
-      backgroundColor:
-        Highcharts.defaultOptions.legend?.backgroundColor ??
-        "rgba(255,255,255,0.25)", // theme
-    },
+
+    // 툴팁 제거시, 포커스된 데이터를 집중적으로 보여줌
+    // tooltip: {
+    //   shared: true,
+    // },
+    // legend: {
+    //   layout: "vertical",
+    //   align: "left",
+    //   x: 80,
+    //   verticalAlign: "top",
+    //   y: 55,
+    //   floating: true,
+    //   backgroundColor:
+    //     Highcharts.defaultOptions.legend?.backgroundColor ??
+    //     "rgba(255,255,255,0.25)", // theme
+    // },
+
+    // 하드코딩 데이터
     series: [
       {
         name: "Rainfall",
@@ -187,49 +126,8 @@ const WeatherChart: React.FC<MultipleAxesChartsProps> = ({
         },
       },
     ],
-    responsive: {
-      rules: [
-        {
-          condition: {
-            maxWidth: 500,
-          },
-          chartOptions: {
-            legend: {
-              floating: false,
-              layout: "horizontal",
-              align: "center",
-              verticalAlign: "bottom",
-              x: 0,
-              y: 0,
-            },
-            yAxis: [
-              {
-                labels: {
-                  align: "right",
-                  x: 0,
-                  y: -6,
-                },
-                showLastLabel: false,
-              },
-              {
-                labels: {
-                  align: "left",
-                  x: 0,
-                  y: -6,
-                },
-                showLastLabel: false,
-              },
-              {
-                visible: false,
-              },
-            ],
-          },
-        },
-      ],
-    },
+    // responsive: {},
   };
 
   return <HighchartsReact highcharts={Highcharts} options={options} />;
-};
-
-export default WeatherChart;
+}

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -2,26 +2,21 @@
 import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
-
 import useData from "@/store/useData";
+import { getBattery } from "@/hooks/useChartsData";
 
 export default function BatteryStatusChart() {
   const { telemetryData, selectedOperationId, validOperationLabels } =
     useData();
-  const batteryData = telemetryData[147] || []; // msgId 147 (BATTERY_STATUS)
 
-  // 선택된 운행의 배터리 정보만 필터링
-  const filteredBatteryData = batteryData
-    .filter((data: any) => selectedOperationId.includes(data.operation))
-    .map((data: any) => ({
-      operationLabel: validOperationLabels[data.operation],
-      timestamp: new Date(data.timestamp),
-      temperature: data.payload.temperature,
-      voltages: data.payload.voltages[0],
-      batteryRemaining: data.payload.batteryRemaining,
-    }));
-
-  console.log(selectedOperationId.map((id) => validOperationLabels[id]));
+  const batteryData = getBattery(telemetryData, selectedOperationId).map(
+    (data) => ({
+      temperature: data[0],
+      voltages: data[1],
+      batteryRemaining: data[2],
+      timestamp: new Date(data[3]),
+    }),
+  );
 
   const options = {
     chart: {
@@ -38,7 +33,7 @@ export default function BatteryStatusChart() {
     xAxis: [
       {
         categories: [],
-        crosshair: true, //마우스 호버시 시각적 가이드 제공 기능
+        crosshair: true,
       },
     ],
     yAxis: [
@@ -72,13 +67,12 @@ export default function BatteryStatusChart() {
       },
     ],
 
-    // 하드코딩 데이터에서 전역 데이터로 변환
     series: [
       {
         name: "배터리 잔량",
         type: "column",
         yAxis: 0,
-        data: filteredBatteryData.map((data) => data.batteryRemaining),
+        data: batteryData.map((data) => data.batteryRemaining),
         tooltip: {
           valueSuffix: " %",
         },
@@ -87,7 +81,7 @@ export default function BatteryStatusChart() {
         name: "배터리 온도",
         type: "spline",
         yAxis: 1,
-        data: filteredBatteryData.map((data) => data.temperature),
+        data: batteryData.map((data) => data.temperature),
         tooltip: {
           valueSuffix: " °C",
         },
@@ -96,7 +90,7 @@ export default function BatteryStatusChart() {
         name: "배터리 전압",
         type: "spline",
         yAxis: 2,
-        data: filteredBatteryData.map((data) => data.voltages),
+        data: batteryData.map((data) => data.voltages),
         marker: {
           enabled: false,
         },

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -10,6 +10,23 @@ if (typeof Highcharts === "object") {
 }
 
 const BatteryStatusChart = () => {
+  const chartComponentRef = React.useRef<HighchartsReact.RefObject>(null);
+  const [chartWidth, setChartWidth] = React.useState(1000);
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      const containerWidth = window.innerWidth;
+      setChartWidth(containerWidth);
+
+      if (chartComponentRef.current) {
+        chartComponentRef.current.chart.reflow();
+      }
+    };
+    handleResize();
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   const { telemetryData, selectedOperationId, validOperationLabels } =
     useData();
   const batteryData = telemetryData[147] || [];
@@ -100,7 +117,7 @@ const BatteryStatusChart = () => {
     return {
       chart: {
         height: 600,
-        width: 1200,
+        width: chartWidth * 0.8,
         zooming: {
           mouseWheel: {
             enabled: true,
@@ -204,32 +221,17 @@ const BatteryStatusChart = () => {
         shared: true,
         crosshairs: true,
       },
-      legend: {
-        layout: "horizontal",
-        align: "center",
-        verticalAlign: "bottom",
-      },
       series: filteredSeries,
-      responsive: {
-        rules: [
-          {
-            condition: { maxWidth: 500 },
-            chartOptions: {
-              legend: {
-                layout: "horizontal",
-                align: "center",
-                verticalAlign: "bottom",
-              },
-            },
-          },
-        ],
-      },
     };
   };
 
   return (
     <div>
-      <HighchartsReact highcharts={Highcharts} options={createChartOptions()} />
+      <HighchartsReact
+        ref={chartComponentRef}
+        highcharts={Highcharts}
+        options={createChartOptions()}
+      />
     </div>
   );
 };

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -43,67 +43,55 @@ export default function BatteryStatusChart() {
     ],
     yAxis: [
       {
+        title: {
+          text: "배터리 잔량 (%)",
+        },
         labels: {
-          format: "{value}",
+          format: "{value}%",
+        },
+        min: 0,
+        max: 100,
+      },
+      {
+        labels: {
+          format: "{value}°C",
         },
         title: {
-          text: "Temperature",
+          text: "온도 (°C)",
         },
         opposite: true,
       },
       {
-        // // Secondary yAxis
-        // gridLineWidth: 0,
-        // title: {
-        //   text: "Rainfall",
-        //   style: {
-        //     color: Highcharts.getOptions().colors?.[0] ?? "#000000",
-        //   },
-        // },
-        // labels: {
-        //   format: "{value} mm",
-        //   style: {
-        //     color: Highcharts.getOptions().colors?.[0] ?? "#000000",
-        //   },
-        // },
-      },
-      {
-        // Tertiary yAxis
-        // gridLineWidth: 0,
-        // title: {
-        //   text: "Sea-Level Pressure",
-        //   style: {
-        //     color: Highcharts.getOptions().colors?.[1] ?? "#000000",
-        //   },
-        // },
-        // labels: {
-        //   format: "{value} mb",
-        //   style: {
-        //     color: Highcharts.getOptions().colors?.[1] ?? "#000000",
-        //   },
-        // },
-        // opposite: true,
+        title: {
+          text: "전압 (V)",
+        },
+        labels: {
+          format: "{value}V",
+        },
+        opposite: true,
       },
     ],
 
-    // 툴팁 제거시, 포커스된 데이터를 집중적으로 보여줌
-    // tooltip: {
-    //   shared: true,
-    // },
-    // legend: {
-    //   layout: "vertical",
-    //   align: "left",
-    //   x: 80,
-    //   verticalAlign: "top",
-    //   y: 55,
-    //   floating: true,
-    //   backgroundColor:
-    //     Highcharts.defaultOptions.legend?.backgroundColor ??
-    //     "rgba(255,255,255,0.25)", // theme
-    // },
-
     // 하드코딩 데이터에서 전역 데이터로 변환
     series: [
+      {
+        name: "배터리 잔량",
+        type: "column",
+        yAxis: 0,
+        data: filteredBatteryData.map((data) => data.batteryRemaining),
+        tooltip: {
+          valueSuffix: " %",
+        },
+      },
+      {
+        name: "배터리 온도",
+        type: "spline",
+        yAxis: 1,
+        data: filteredBatteryData.map((data) => data.temperature),
+        tooltip: {
+          valueSuffix: " °C",
+        },
+      },
       {
         name: "배터리 전압",
         type: "spline",
@@ -117,25 +105,7 @@ export default function BatteryStatusChart() {
           valueSuffix: " V",
         },
       },
-      {
-        name: "배터리 온도",
-        type: "spline",
-        data: filteredBatteryData.map((data) => data.temperature),
-        tooltip: {
-          valueSuffix: " °C",
-        },
-      },
-      {
-        name: "배터리 잔량",
-        type: "column",
-        yAxis: 1,
-        data: filteredBatteryData.map((data) => data.batteryRemaining),
-        tooltip: {
-          valueSuffix: " %",
-        },
-      },
     ],
-    // responsive: {},
   };
 
   return <HighchartsReact highcharts={Highcharts} options={options} />;

--- a/src/components/log/charts/MultipleAxesCharts.tsx
+++ b/src/components/log/charts/MultipleAxesCharts.tsx
@@ -3,111 +3,159 @@ import React from "react";
 import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import useData from "@/store/useData";
-import { getBattery } from "@/hooks/useChartsData";
 
-export default function BatteryStatusChart() {
+const BatteryStatusChart = () => {
   const { telemetryData, selectedOperationId, validOperationLabels } =
     useData();
+  const batteryData = telemetryData[147] || [];
 
-  const batteryData = getBattery(telemetryData, selectedOperationId).map(
-    (data) => ({
-      temperature: data[0],
-      voltages: data[1],
-      batteryRemaining: data[2],
-      timestamp: new Date(data[3]).getTime(),
-    }),
+  const filteredData = batteryData.filter((data) =>
+    selectedOperationId.includes(data.operation),
   );
 
-  const options = {
-    chart: {
-      // zooming: {
-      //   type: "xy",
-      // },
-      height: 400,
-      width: 1200,
-    },
-    title: {
-      text: "드론 배터리 데이터",
-    },
+  const groupByDate = () => {
+    const dateGroups = new Map();
 
-    xAxis: [
-      {
-        categories: batteryData.map((data) =>
-          new Date(data.timestamp).toLocaleTimeString("ko-KR", {
-            hour: "2-digit",
-            minute: "2-digit",
-            // second: "2-digit",
-            hour12: false,
-          }),
-        ),
-        crosshair: true,
-      },
-    ],
-    yAxis: [
-      {
-        title: {
-          text: "배터리 잔량 (%)",
-        },
-        labels: {
-          format: "{value}%",
-        },
-        min: 0,
-        max: 100,
-      },
-      {
-        labels: {
-          format: "{value}°C",
-        },
-        title: {
-          text: "온도 (°C)",
-        },
-        opposite: true,
-      },
-      {
-        title: {
-          text: "전압 (V)",
-        },
-        labels: {
-          format: "{value}V",
-        },
-        opposite: true,
-      },
-    ],
+    filteredData.forEach((data) => {
+      const date = new Date(data.timestamp).toLocaleDateString();
+      if (!dateGroups.has(date)) {
+        dateGroups.set(date, []);
+      }
+      dateGroups.get(date).push(data);
+    });
 
-    series: [
-      {
-        name: "배터리 잔량",
-        type: "column",
-        yAxis: 0,
-        data: batteryData.map((data) => data.batteryRemaining),
-        tooltip: {
-          valueSuffix: " %",
-        },
-      },
-      {
-        name: "배터리 온도",
-        type: "spline",
-        yAxis: 1,
-        data: batteryData.map((data) => data.temperature),
-        tooltip: {
-          valueSuffix: " °C",
-        },
-      },
-      {
-        name: "배터리 전압",
-        type: "spline",
-        yAxis: 2,
-        data: batteryData.map((data) => data.voltages),
-        marker: {
-          enabled: false,
-        },
-        dashStyle: "shortdot",
-        tooltip: {
-          valueSuffix: " V",
-        },
-      },
-    ],
+    return dateGroups;
   };
 
-  return <HighchartsReact highcharts={Highcharts} options={options} />;
-}
+  const createChartOptions = (date: string, dateData: any[]) => {
+    const colorSchemes = {
+      battery: ["#00ff00", "#33cc33", "#269926", "#1a661a"], // green
+      temperature: ["#ff6666", "#ff3333", "#ff0000", "#cc0000"], // red
+      voltage: ["#3366ff", "#0044cc", "#003399", "#002266"], // blue
+    };
+
+    const currentDateData = dateData.filter(
+      (data) => new Date(data.timestamp).toLocaleDateString() === date,
+    );
+
+    const series = selectedOperationId.map((opId, index) => {
+      const operationData = currentDateData
+        .filter((data) => data.operation === opId)
+        .sort(
+          (a, b) =>
+            new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
+        );
+
+      if (operationData.length === 0) return [];
+
+      const times = operationData.map((d) => new Date(d.timestamp).getTime());
+
+      return [
+        {
+          name: `배터리 잔량 (${validOperationLabels[opId]})`,
+          type: "area",
+          yAxis: 2,
+          color: colorSchemes.battery[index % colorSchemes.battery.length],
+          data: operationData.map((d, i) => [
+            times[i],
+            d.payload.batteryRemaining,
+          ]),
+          tooltip: { valueSuffix: "%" },
+        },
+        {
+          name: `온도 (${validOperationLabels[opId]})`,
+          type: "spline",
+          dashStyle: "shortdot",
+          yAxis: 0,
+          color:
+            colorSchemes.temperature[index % colorSchemes.temperature.length],
+          data: operationData.map((d, i) => [times[i], d.payload.temperature]),
+          tooltip: { valueSuffix: "°C" },
+        },
+        {
+          name: `전압 (${validOperationLabels[opId]})`,
+          type: "line",
+          yAxis: 1,
+          color: colorSchemes.voltage[index % colorSchemes.voltage.length],
+          data: operationData.map((d, i) => [times[i], d.payload.voltages[0]]),
+          tooltip: { valueSuffix: "V" },
+        },
+      ];
+    });
+
+    const filteredSeries = series
+      .flat()
+      .filter((s) => s.data && s.data.length > 0);
+
+    return {
+      chart: {
+        zooming: { type: "xy" },
+        height: 400,
+        width: 1200,
+      },
+      title: { text: `배터리 상태: ${date}` },
+      xAxis: {
+        type: "datetime",
+        crosshair: true,
+      },
+      yAxis: [
+        {
+          title: { text: "온도 (°C)" },
+          labels: { format: "{value}°C" },
+        },
+        {
+          title: { text: "전압 (V)" },
+          labels: { format: "{value}V" },
+          opposite: true,
+        },
+        {
+          title: { text: "배터리 잔량 (%)" },
+          labels: { format: "{value}%" },
+          max: 100,
+          min: 0,
+          opposite: true,
+        },
+      ],
+      tooltip: {
+        shared: true,
+        crosshairs: true,
+      },
+      legend: {
+        layout: "horizontal",
+        align: "center",
+        verticalAlign: "bottom",
+      },
+      series: filteredSeries,
+      responsive: {
+        rules: [
+          {
+            condition: { maxWidth: 500 },
+            chartOptions: {
+              legend: {
+                layout: "horizontal",
+                align: "center",
+                verticalAlign: "bottom",
+              },
+            },
+          },
+        ],
+      },
+    };
+  };
+
+  const dateGroups = groupByDate();
+  return (
+    <div>
+      {Array.from(dateGroups).map(([date, dateData]) => (
+        <div key={date}>
+          <HighchartsReact
+            highcharts={Highcharts}
+            options={createChartOptions(date, dateData)}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BatteryStatusChart;


### PR DESCRIPTION
*지난 주 백엔드 코드를 작성한 이후에 저희가 프론트엔드 관련 코드만 작성하고 있어, 백엔드 관련 코드리뷰가 아닌 점 양해를 부탁드립니다. 🙇‍♂️
## 구현 내용
[highcharts 라이브러리 예제](https://www.highcharts.com/demo/highcharts/combo-multi-axes)코드를 가져와 하드코딩된 부분을 저희 데이터로 교체하고 시각화하는 과정 중에 있습니다.
<br>

## 주요 기능
- 그래프의 x축은 드론이 운행한 시간을 출력하고, y축에는 배터리 잔량, 배터리 온도, 배터리 전압 3가지 데이터를 표시합니다.
- 좌측 사이드바에는 3개의 드론의 목록이 보이며 해당 드론이 운행한 날짜를 체크할 수 있도록 하여, 체크한 운행의 배터리 상태를 체크합니다.
<br>

## 고민되는 지점
- 원래는 한 그래프 안에 전체 드론의 운행 정보를 표현하려고 했으나, 날짜가 다른 경우 첫 번째 이미지와 같이 데이터가 극단적으로 쏠려서 확인을 할 수 없는 상태입니다.
- 그래서 하단의 이미지와 같이 날짜가 같은 드론 데이터만 모아 표기하는 방식으로 어느정도는 해결은 했습니다. (확정이 아니라 시험삼아 해본 내용이라 이 구현 내용의 코드가 리뷰안에 포함되어 있지는 않습니다!)
- 하지만 날짜가 많아지면 그래프 역시 많아지는 것이기때문에 좋은 해결책은 아니라고 생각합니다.

이 그래프 외에도 위도나 경도 등을 표시하는 그래프가 추가되기때문에, 이를 모두 날짜마다 그래프를 생성하는 로직을 짜면 화면에 렌더링되는 내용도 많고 그만큼 과부하도 걸릴 것 같습니다. 날짜가 꽤 먼 경우 이를 한번에 표현하려고 하면 그래프 뿐만 아니라 드론의 경로를 맵 위에 시간별로 표시할 때도 문제가 되고 있습니다.. 날짜가 다른 데이터를 한 번에 보여주는 방식을 어떻게 하면 잘 보여줄 수 있을지, 혹시 참고할만한 레퍼런스가 있을지 궁금합니다!

<img width="1474" alt="스크린샷 2025-01-21 오전 11 08 45" src="https://github.com/user-attachments/assets/54ca4456-c204-4c06-bf6c-1d9238a6c63f" />

<img width="1216" alt="스크린샷 2025-01-21 오전 11 07 23" src="https://github.com/user-attachments/assets/0eb620d0-8ac5-4865-b7ca-b35f131dca19" />

*데이터가 현재 시간별로 모두 똑같아서 일직선으로 그려지는 문제가 있는데요, 원본 데이터의 문제로 보여 확인 중에 있습니다! 참고 부탁드립니다.
