### PR TITLE
[log] 차트에 데이터 랜더링시 각각 드론의 따라 분리 로직

### DIFF
--- a/src/components/log/charts/SynchronisedCharts.tsx
+++ b/src/components/log/charts/SynchronisedCharts.tsx
@@ -5,6 +5,7 @@ import HighchartsReact from "highcharts-react-official";
 import HighchartsExporting from "highcharts/modules/exporting";
 import { getSatellites, getPosition, getBattery } from "@/hooks/useChartsData";
 import useData from "@/store/useData";
+import { group } from "console";
 
 if (typeof Highcharts === "object") {
   HighchartsExporting(Highcharts);
@@ -19,7 +20,7 @@ declare module "highcharts" {
 interface Dataset {
   name: string;
   type: string;
-  unit: string;
+  unit: number[];
   data: number[];
 }
 
@@ -54,46 +55,30 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
         const formattedLat: Dataset = {
           name: "위도",
           type: "line",
-          unit: "",
+          unit: position.map((item) => item[0]),
           data: position.map((item) => item[1]),
         };
 
         const formattedLon: Dataset = {
           name: "경도",
           type: "line",
-          unit: "",
+          unit: position.map((item) => item[0]),
           data: position.map((item) => item[2]),
         };
 
         const formattedAlt: Dataset = {
           name: "고도",
           type: "line",
-          unit: "",
+          unit: position.map((item) => item[0]),
           data: position.map((item) => item[3]),
         };
 
         const formattedSatellites: Dataset = {
           name: "드론 갯수",
           type: "line",
-          unit: "",
-          data: satelites.map((item) => item[1]), // [number, number][] 중 첫 번째 값만 추출
+          unit: satelites.map((item) => item[0]),
+          data: satelites.map((item) => item[1]),
         };
-
-        // const formattedSatellites = satellites.map((data) => ({
-        //   name: `Satellites`,
-        //   type: "line",
-        //   unit: "count",
-        //   data,
-        // }));
-
-        // const formattedBattery = [
-        //   {
-        //     name: "Battery",
-        //     type: "area",
-        //     unit: "%",
-        //     data: battery.map((item) => item[2]), // battery_remaining
-        //   },
-        // ];
 
         setChartData([
           formattedLat,
@@ -131,7 +116,56 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
   const renderChart = (dataset: Dataset, index: number) => {
     if (!xData.length) return null;
 
-    const data = dataset.data.map((val: number, i: number) => [xData[i], val]);
+    /* 
+    mongodb에서 필터링 된 데이터를 저장하는 부분
+    175번줄에 있는 dataset1, dataset2, dataset3,를 수정하여 사용
+    단 dataset.unit 부분은 드론의 분류기준으로 실제 data 에 삽입을 하면안됨
+    dataset.unit 이 동일한 데이터들을 분류 하고 unit 값을 뺀 데이터를 여러 생성해 그것을 177줄 series 부분에 삽입을 해야함
+    ex) 
+    const data = dataset.data.map((val: number, i: number) => [
+      xData[i],
+      val,
+    ]); => dataset.unit[0] 기준 분류됨
+    const data2 = dataset.data.map((val: number, i: number) => [
+      xData[i],
+      val,
+    ]); -> dataset.unit[1] 기준 분류됨
+
+    */
+    const data = dataset.data.map((val: number, i: number) => [
+      xData[i],
+      val,
+      dataset.unit[i],
+    ]);
+
+    // dataset.unit 값을 중복 제거하여 고유값을 가져옵니다.
+    const uniqueUnits = Array.from(new Set(dataset.unit));
+
+    // 각 uniqueUnit 값에 대해 데이터를 분류하여 저장할 변수들 초기화
+    let data1: number[][] = [];
+    let data2: number[][] = [];
+    let data3: number[][] = [];
+
+    // dataset.data를 통해 각 unit별로 데이터를 분류
+    dataset.data.forEach((val: number, i: number) => {
+      const unit = dataset.unit[i]; // 현재 unit 값
+      const point = [xData[i], val]; // xData와 데이터를 묶은 포인트
+
+      // unit 값에 따라 데이터를 해당 data1, data2, data3로 분류
+      switch (unit) {
+        case uniqueUnits[0]:
+          data1.push(point);
+          break;
+        case uniqueUnits[1]:
+          data2.push(point);
+          break;
+        case uniqueUnits[2]:
+          data3.push(point);
+          break;
+        default:
+          break;
+      }
+    });
 
     const colours = Highcharts.getOptions().colors;
     const colour =
@@ -167,10 +201,11 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
       },
       yAxis: {
         title: {
-          text: dataset.unit,
+          // text: dataset.unit,
+          tesxt: " ",
         },
         min: minYValue,
-        max: maxYValue,
+        max: maxYValue * 2,
       },
       plotOptions: {
         series: {
@@ -179,11 +214,28 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
           },
         },
       },
+
+      // 데이터가 차트로 변환 되는 부분 data: data는 데이터값, 나머지 부분은 수정 불필요
       series: [
+        // 첫 번째 라인: dataset1
         {
-          name: dataset.name,
+          name: `${dataset.name} 1`,
           type: dataset.type,
-          data: data,
+          data: data1, // 첫 번째 유닛 데이터만 사용
+          color: colour,
+        },
+        // 두 번째 라인: dataset2
+        {
+          name: `${dataset.name} 2`,
+          type: dataset.type,
+          data: data2, // 두 번째 유닛 데이터만 사용
+          color: colour,
+        },
+        // 세 번째 라인 : dataset3
+        {
+          name: `${dataset.name} 3`,
+          type: dataset.type,
+          data: data3, // 세 번째 유닛 데이터만 사용
           color: colour,
         },
       ],
@@ -201,24 +253,24 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
     );
   };
 
-  const handleMouseMove = (
-    e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
-  ) => {
-    Highcharts.charts.forEach((chart) => {
-      if (!chart) return;
+  // const handleMouseMove = (
+  //   e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
+  // ) => {
+  //   Highcharts.charts.forEach((chart) => {
+  //     if (!chart) return;
 
-      const normalizedEvent = chart.pointer.normalize(e as any);
-      const point = chart.series[0].searchPoint(normalizedEvent, true);
-      if (point) {
-        point.highlight(normalizedEvent);
-      }
-    });
-  };
+  //     const normalizedEvent = chart.pointer.normalize(e as any);
+  //     const point = chart.series[0].searchPoint(normalizedEvent, true);
+  //     if (point) {
+  //       point.highlight(normalizedEvent);
+  //     }
+  //   });
+  // };
 
   return (
     <div
-      onMouseMove={handleMouseMove}
-      onTouchMove={handleMouseMove}
+      // onMouseMove={handleMouseMove}
+      // onTouchMove={handleMouseMove}
       className="grid grid-cols-1"
     >
       {loading ? (

--- a/src/components/log/charts/SynchronisedCharts.tsx
+++ b/src/components/log/charts/SynchronisedCharts.tsx
@@ -1,11 +1,14 @@
 "use client";
-import React, { useEffect, useState } from "react";
-import Highcharts from "highcharts";
-import HighchartsReact from "highcharts-react-official";
+import React from "react";
+import Highcharts, { chart } from "highcharts";
 import HighchartsExporting from "highcharts/modules/exporting";
-import { getSatellites, getPosition, getBattery } from "@/hooks/useChartsData";
 import useData from "@/store/useData";
-import { group } from "console";
+
+import {
+  renderChart,
+  useChartDataTransform,
+  useChartXData,
+} from "@/hooks/useSynchronisedChartsData ";
 
 if (typeof Highcharts === "object") {
   HighchartsExporting(Highcharts);
@@ -17,244 +20,30 @@ declare module "highcharts" {
   }
 }
 
-interface Dataset {
-  name: string;
-  type: string;
-  unit: number[];
-  data: number[];
-}
-
 interface SynchronisedChartsProps {
   numOfDatasets?: number;
   chartWidth?: number;
   chartHeight?: number;
 }
 
+export const DefaultSynchronisedChartsProps = {
+  numOfDatasets: 3,
+  chartWidth: 400,
+  chartHeight: 200,
+};
+
 const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
-  numOfDatasets = 3,
-  chartWidth = 400,
-  chartHeight = 200,
+  numOfDatasets = DefaultSynchronisedChartsProps.numOfDatasets,
+  chartWidth = DefaultSynchronisedChartsProps.chartWidth,
+  chartHeight = DefaultSynchronisedChartsProps.chartHeight,
 }) => {
   const { telemetryData, selectedOperationId } = useData();
 
-  const [chartData, setChartData] = useState<Dataset[]>([]);
-  const [xData, setXData] = useState<number[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        setLoading(true);
-
-        const satelites = getSatellites(telemetryData, selectedOperationId);
-        const position = getPosition(telemetryData, selectedOperationId);
-
-        const xAxisData = position.map((item) => item[4]);
-        setXData(xAxisData);
-
-        const formattedLat: Dataset = {
-          name: "위도",
-          type: "line",
-          unit: position.map((item) => item[0]),
-          data: position.map((item) => item[1]),
-        };
-
-        const formattedLon: Dataset = {
-          name: "경도",
-          type: "line",
-          unit: position.map((item) => item[0]),
-          data: position.map((item) => item[2]),
-        };
-
-        const formattedAlt: Dataset = {
-          name: "고도",
-          type: "line",
-          unit: position.map((item) => item[0]),
-          data: position.map((item) => item[3]),
-        };
-
-        const formattedSatellites: Dataset = {
-          name: "드론 갯수",
-          type: "line",
-          unit: satelites.map((item) => item[0]),
-          data: satelites.map((item) => item[1]),
-        };
-
-        setChartData([
-          formattedLat,
-          formattedLon,
-          formattedAlt,
-          formattedSatellites,
-        ]);
-      } catch (error) {
-        console.error("Error fetching data:", error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [telemetryData, selectedOperationId]);
-
-  useEffect(() => {
-    const oldReset = Highcharts.Pointer.prototype.reset;
-    const oldHighlight = Highcharts.Point.prototype.highlight;
-
-    Highcharts.Pointer.prototype.reset = () => {};
-    Highcharts.Point.prototype.highlight = function (event) {
-      this.onMouseOver();
-      this.series.chart.tooltip.refresh(this);
-      this.series.chart.xAxis[0].drawCrosshair(event, this);
-    };
-
-    return () => {
-      Highcharts.Pointer.prototype.reset = oldReset;
-      Highcharts.Point.prototype.highlight = oldHighlight;
-    };
-  }, []);
-
-  const renderChart = (dataset: Dataset, index: number) => {
-    if (!xData.length) return null;
-
-    /* 
-    mongodb에서 필터링 된 데이터를 저장하는 부분
-    175번줄에 있는 dataset1, dataset2, dataset3,를 수정하여 사용
-    단 dataset.unit 부분은 드론의 분류기준으로 실제 data 에 삽입을 하면안됨
-    dataset.unit 이 동일한 데이터들을 분류 하고 unit 값을 뺀 데이터를 여러 생성해 그것을 177줄 series 부분에 삽입을 해야함
-    ex) 
-    const data = dataset.data.map((val: number, i: number) => [
-      xData[i],
-      val,
-    ]); => dataset.unit[0] 기준 분류됨
-    const data2 = dataset.data.map((val: number, i: number) => [
-      xData[i],
-      val,
-    ]); -> dataset.unit[1] 기준 분류됨
-
-    */
-    const data = dataset.data.map((val: number, i: number) => [
-      xData[i],
-      val,
-      dataset.unit[i],
-    ]);
-
-    /*
-
-    // dataset.unit 값을 중복 제거하여 고유값을 가져옵니다.
-    const uniqueUnits = Array.from(new Set(dataset.unit));
-
-    // 각 uniqueUnit 값에 대해 데이터를 분류하여 저장할 변수들 초기화
-    let data1: number[][] = [];
-    let data2: number[][] = [];
-    let data3: number[][] = [];
-
-    // dataset.data를 통해 각 unit별로 데이터를 분류
-    dataset.data.forEach((val: number, i: number) => {
-      const unit = dataset.unit[i]; // 현재 unit 값
-      const point = [xData[i], val]; // xData와 데이터를 묶은 포인트
-
-      // unit 값에 따라 데이터를 해당 data1, data2, data3로 분류
-      switch (unit) {
-        case uniqueUnits[0]:
-          data1.push(point);
-          break;
-        case uniqueUnits[1]:
-          data2.push(point);
-          break;
-        case uniqueUnits[2]:
-          data3.push(point);
-          break;
-        default:
-          break;
-      }
-    });
-    */
-
-    const colours = Highcharts.getOptions().colors;
-    const colour =
-      colours && colours.length > index ? colours[index] : undefined;
-
-    const maxYValue = Math.max(...dataset.data); // y축 최대값 계산
-    const minYValue = Math.min(...dataset.data); // y축 최대값 계산
-
-    const options = {
-      chart: {
-        zooming: {
-          type: "x",
-        },
-        width: chartWidth,
-        height: chartHeight,
-      },
-      title: {
-        text: dataset.name,
-      },
-      xAxis: {
-        crosshair: true,
-        labels: {
-          format: "{value}",
-        },
-        events: {
-          afterSetExtremes: function (event: Highcharts.ExtremesObject) {
-            Highcharts.charts.forEach((chart) => {
-              if (!chart) return null;
-              chart.xAxis[0].setExtremes(event.min, event.max);
-            });
-          },
-        },
-      },
-      yAxis: {
-        title: {
-          // text: dataset.unit,
-          tesxt: " ",
-        },
-        min: minYValue,
-        max: maxYValue * 2,
-      },
-      plotOptions: {
-        series: {
-          animation: {
-            duration: 2500,
-          },
-        },
-      },
-
-      // 데이터가 차트로 변환 되는 부분 data: data는 데이터값, 나머지 부분은 수정 불필요
-      series: [
-        // 첫 번째 라인: dataset1
-        {
-          name: `${dataset.name} 1`,
-          type: dataset.type,
-          data: data, // 첫 번째 유닛 데이터만 사용
-          color: colour,
-        },
-        // 두 번째 라인: dataset2
-        {
-          name: `${dataset.name} 2`,
-          type: dataset.type,
-          data: data, // 두 번째 유닛 데이터만 사용
-          color: colour,
-        },
-        // 세 번째 라인 : dataset3
-        {
-          name: `${dataset.name} 3`,
-          type: dataset.type,
-          data: data, // 세 번째 유닛 데이터만 사용
-          color: colour,
-        },
-      ],
-      tooltip: {
-        valueSuffix: ` ${dataset.unit}`,
-      },
-    };
-
-    return (
-      <HighchartsReact
-        highcharts={Highcharts}
-        options={options}
-        key={dataset.name}
-      />
-    );
-  };
+  const chartData = useChartDataTransform({
+    telemetryData,
+    selectedOperationId,
+  });
+  const xData = useChartXData(telemetryData, selectedOperationId);
 
   // const handleMouseMove = (
   //   e: React.MouseEvent<HTMLDivElement> | React.TouchEvent<HTMLDivElement>,
@@ -276,13 +65,13 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
       // onTouchMove={handleMouseMove}
       className="grid grid-cols-1"
     >
-      {loading ? (
+      {chartData.length == 0 ? (
         <p>Loading...</p>
       ) : (
         chartData
           .slice(0, numOfDatasets)
           .map((dataset, index) => (
-            <div key={dataset.name}>{renderChart(dataset, index)}</div>
+            <div key={dataset.name}>{renderChart(dataset, index, xData)}</div>
           ))
       )}
     </div>

--- a/src/components/log/charts/SynchronisedCharts.tsx
+++ b/src/components/log/charts/SynchronisedCharts.tsx
@@ -138,6 +138,8 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
       dataset.unit[i],
     ]);
 
+    /*
+
     // dataset.unit 값을 중복 제거하여 고유값을 가져옵니다.
     const uniqueUnits = Array.from(new Set(dataset.unit));
 
@@ -166,6 +168,7 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
           break;
       }
     });
+    */
 
     const colours = Highcharts.getOptions().colors;
     const colour =
@@ -221,21 +224,21 @@ const SynchronisedCharts: React.FC<SynchronisedChartsProps> = ({
         {
           name: `${dataset.name} 1`,
           type: dataset.type,
-          data: data1, // 첫 번째 유닛 데이터만 사용
+          data: data, // 첫 번째 유닛 데이터만 사용
           color: colour,
         },
         // 두 번째 라인: dataset2
         {
           name: `${dataset.name} 2`,
           type: dataset.type,
-          data: data2, // 두 번째 유닛 데이터만 사용
+          data: data, // 두 번째 유닛 데이터만 사용
           color: colour,
         },
         // 세 번째 라인 : dataset3
         {
           name: `${dataset.name} 3`,
           type: dataset.type,
-          data: data3, // 세 번째 유닛 데이터만 사용
+          data: data, // 세 번째 유닛 데이터만 사용
           color: colour,
         },
       ],

--- a/src/hooks/useChartsData.tsx
+++ b/src/hooks/useChartsData.tsx
@@ -3,7 +3,7 @@ export const getSatellites = (telemetryData: any, operationId: string[]) => {
   return satelitesData
     .filter((data: any) => operationId.includes(data.operation))
     .map((data: any) => {
-      const id = data.operationId;
+      const id = data.operation;
       const satelitesCount = data.payload.satellitesVisible;
       const timestamp = data.timestamp;
       return [id, satelitesCount, timestamp];
@@ -15,7 +15,7 @@ export const getPosition = (telemetryData: any, operationId: string[]) => {
   return positionData
     .filter((data: any) => operationId.includes(data.operation))
     .map((data: any) => {
-      const id = data.operationId;
+      const id = data.operation;
       const lat = data.payload.lat * 1e-7;
       const lon = data.payload.lon * 1e-7;
       const alt = data.payload.alt * 1e-7;

--- a/src/hooks/useSynchronisedChartsData .tsx
+++ b/src/hooks/useSynchronisedChartsData .tsx
@@ -1,0 +1,228 @@
+import { Dataset } from "@/types/api";
+import { getSatellites, getPosition } from "@/hooks/useChartsData";
+import { useEffect, useState } from "react";
+import HighchartsReact from "highcharts-react-official";
+import Highcharts from "highcharts";
+import { DefaultSynchronisedChartsProps } from "@/components/log/charts/SynchronisedCharts";
+
+interface useChartDataTransformProps {
+  telemetryData: any;
+  selectedOperationId: string[];
+}
+
+const useChartXData = (telemetryData: any, selectedOperationId: string[]) => {
+  const [xData, setXData] = useState<number[]>([]);
+
+  useEffect(() => {
+    const position = getPosition(telemetryData, selectedOperationId);
+    const satelites = getSatellites(telemetryData, selectedOperationId);
+    const xAxisData = satelites
+      .filter((satellite) => position.some((pos) => pos[4] === satellite[2]))
+      .map((satellite) => satellite[2]);
+
+    setXData(xAxisData);
+  }, [telemetryData, selectedOperationId]);
+
+  return xData;
+};
+
+// TODO: useEffect & fetchData 코드 내 직접 작성 대신 아래 커스텀 훅 사용
+const useChartDataTransform = ({
+  telemetryData,
+  selectedOperationId,
+}: useChartDataTransformProps) => {
+  const [chartData, setChartData] = useState<Dataset[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+
+        const position = getPosition(telemetryData, selectedOperationId);
+        const satelites = getSatellites(telemetryData, selectedOperationId);
+
+        if (!position.length || !satelites.length) {
+          return null;
+        }
+
+        const formattedLat: Dataset = {
+          name: "위도",
+          type: "line",
+          unit: position.map((item) => item[0]),
+          data: position.map((item) => item[1]),
+        };
+
+        const formattedLon: Dataset = {
+          name: "경도",
+          type: "line",
+          unit: position.map((item) => item[0]),
+          data: position.map((item) => item[2]),
+        };
+
+        const formattedAlt: Dataset = {
+          name: "고도",
+          type: "line",
+          unit: position.map((item) => item[0]),
+          data: position.map((item) => item[3]),
+        };
+
+        const formattedSatellites: Dataset = {
+          name: "드론 갯수",
+          type: "line",
+          unit: satelites.map((item) => item[0]),
+          data: satelites.map((item) => item[1]),
+        };
+
+        setChartData([
+          formattedLat,
+          formattedLon,
+          formattedAlt,
+          formattedSatellites,
+        ]);
+      } catch (error) {
+        console.error(error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [telemetryData, selectedOperationId]);
+  return chartData;
+};
+// TODO: 컴포넌트 내 차트 옵션생성 로직 추출 목적
+const createChartOptions = (
+  dataset: Dataset,
+  index: number,
+  xData: number[],
+) => {
+  if (!xData.length) return null;
+
+  const data = dataset.data.map((val: number, i: number) => [
+    xData[i],
+    val,
+    dataset.unit[i],
+  ]);
+
+  // const categorizedData: Record<string, any[]> = {};
+
+  // // 데이터를 분류
+  // data.forEach((item) => {
+  //   const id = item[2]; // 2번째 부분의 id 값
+  //   if (!categorizedData[id]) {
+  //     categorizedData[id] = []; // 해당 id에 대한 배열 초기화
+  //   }
+  //   categorizedData[id].push(item); // 데이터를 해당 id 배열에 추가
+  // });
+
+  const groupData = groupDataById(data);
+
+  const colours = Highcharts.getOptions().colors;
+  const colour = colours && colours.length > index ? colours[index] : undefined;
+  const maxYValue = Math.max(...dataset.data); // y축 최대값 계산
+  const minYValue = Math.min(...dataset.data); // y축 최대값 계산
+
+  const options = {
+    chart: {
+      zooming: {
+        type: "x",
+      },
+      width: DefaultSynchronisedChartsProps.chartWidth,
+      height: DefaultSynchronisedChartsProps.chartHeight,
+    },
+    title: {
+      text: dataset.name,
+    },
+    xAxis: {
+      crosshair: true,
+      labels: {
+        format: "{value}",
+      },
+      events: {
+        afterSetExtremes: function (event: Highcharts.ExtremesObject) {
+          Highcharts.charts.forEach((chart) => {
+            if (!chart) return null;
+            chart.xAxis[0].setExtremes(event.min, event.max);
+          });
+        },
+      },
+    },
+    yAxis: {
+      title: {
+        // text: dataset.unit,
+        text: " ",
+      },
+      min: minYValue,
+      max: maxYValue,
+    },
+    plotOptions: {
+      series: {
+        animation: {
+          duration: 2500,
+        },
+      },
+    },
+
+    // 데이터가 차트로 변환 되는 부분 data: data는 데이터값, 나머지 부분은 수정 불필요
+    series: [
+      // 첫 번째 라인: dataset1
+      {
+        name: `${dataset.name} 1`,
+        type: dataset.type,
+        data: groupData["677730f8e8f8dd840dd35153"], // 첫 번째 유닛 데이터만 사용
+        color: colour,
+        turboThreshold: 5000,
+      },
+      // 두 번째 라인: dataset2
+      {
+        name: `${dataset.name} 2`,
+        type: dataset.type,
+        data: groupData["6777325ae8f8dd840dd35163"], // 두 번째 유닛 데이터만 사용
+        color: "red",
+        turboThreshold: 5000,
+      },
+      // 세 번째 라인 : dataset3
+      {
+        name: `${dataset.name} 3`,
+        type: dataset.type,
+        data: groupData["677745dee8f8dd840dd35186"], // 세 번째 유닛 데이터만 사용
+        color: "green",
+        turboThreshold: 5000,
+      },
+    ],
+    tooltip: {
+      valueSuffix: ` ${dataset.name}`,
+    },
+  };
+
+  return options;
+};
+
+const groupDataById = (data: any[]) => {
+  const groupData: Record<string, any[]> = {};
+
+  // 데이터를 분류
+  data.forEach((item) => {
+    const id = item[2];
+    if (!groupData[id]) {
+      groupData[id] = [];
+    }
+    groupData[id].push(item);
+  });
+  return groupData;
+};
+
+const renderChart = (dataset: Dataset, index: number, xData: number[]) => {
+  const options = createChartOptions(dataset, index, xData);
+  if (!options) return null;
+  return (
+    <HighchartsReact
+      highcharts={Highcharts}
+      options={options}
+      key={dataset.name}
+    />
+  );
+};
+
+export { useChartDataTransform, renderChart, useChartXData };

--- a/src/types/api.d.ts
+++ b/src/types/api.d.ts
@@ -17,3 +17,10 @@ export interface Telemetries {
   timestamp: string;
   __v: number;
 }
+
+export interface Dataset {
+  name: string;
+  type: string;
+  unit: number[];
+  data: number[];
+}


### PR DESCRIPTION
- 사이드바에서 선택한 드론들을 하나의 배열에 삽입하고
- 차트에 랜더링시 배열에서 드론들의 operation값에 따라 데이터를 구분시켜 여러개의 정보를 담고자 했습니다.
- ex) 드론을 2개 선택시 하나의 차트에 2개의 line이 생성됨
- operation의 정보는 dataset.unit 항목에 저장이후 이것을 랜더링시 이걸 기준으로 date들을 분류시켜 각각 렌더링 하고자햇습니다
- 다만 구현 로직에 있어 어려움을 느껴 질문드립니다.
- SynchronisedCharts.tsx 파일의 120줄에 자세한 설명을 적었습니다.
- 