### PR TITLE
[map] 재생바 시간별 Status Panel 정보 출력

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -83,7 +83,7 @@ export default function MapPage() {
             <AttitudePanel />
           </div>
         </div>
-        <div className="absolute bottom-7 left-1/2 z-10 w-1/2 min-w-80 -translate-x-1/2">
+        <div className="absolute bottom-7 left-1/2 z-10 w-2/3 min-w-80 -translate-x-1/2">
           <FlightProgressBar
             progress={progress}
             setProgress={setProgress}

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -74,6 +74,7 @@ export default function MapPage() {
             <StatusPanel
               progress={progress}
               allTimestamps={allTimestamps}
+              operationTimestamps={operationTimestamps}
               selectedOperationId={selectedOperationId}
               selectedFlight={selectedFlight}
             />

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -19,12 +19,20 @@ export default function MapPage() {
   const { selectedOperationId } = useData();
   const [selectedFlight, setSelectedFlight] = useState(selectedOperationId[0]);
   const [progress, setProgress] = useState(0);
-  const [selectedTimestamp, setSelectedTimestamp] = useState<number[]>([]);
+  const [operationTimestamps, setOperationTimestamps] = useState<
+    Record<string, number[]>
+  >({});
+  const [allTimestamps, setAllTimestamps] = useState<number[]>([]);
 
   useEffect(() => {
     setSelectedFlight(selectedOperationId[0]);
     setProgress(0);
   }, [selectedOperationId]);
+
+  useEffect(() => {
+    const allTimestamps = Object.values(operationTimestamps).flat();
+    setAllTimestamps(allTimestamps.sort((a, b) => a - b));
+  }, [operationTimestamps]);
 
   const toggleStatusPanel = () => {
     setIsStatusOpen(!isStatusOpen);
@@ -49,8 +57,9 @@ export default function MapPage() {
         <div className="h-full">
           <MapView
             progress={progress}
-            selectedTimestamp={selectedTimestamp}
-            setSelectedTimestamp={setSelectedTimestamp}
+            operationTimestamps={operationTimestamps}
+            setOperationTimestamps={setOperationTimestamps}
+            allTimestamps={allTimestamps}
             onMarkerClick={setSelectedFlight}
           />
         </div>
@@ -64,7 +73,7 @@ export default function MapPage() {
           >
             <StatusPanel
               progress={progress}
-              selectedTimestamp={selectedTimestamp}
+              allTimestamps={allTimestamps}
               selectedOperationId={selectedOperationId}
               selectedFlight={selectedFlight}
             />
@@ -77,7 +86,7 @@ export default function MapPage() {
           <FlightProgressBar
             progress={progress}
             setProgress={setProgress}
-            timestamp={selectedTimestamp}
+            allTimestamps={allTimestamps}
           />
           <div className="flex justify-center">
             <ControlPanel

--- a/src/components/map/ControlPanel.tsx
+++ b/src/components/map/ControlPanel.tsx
@@ -39,7 +39,7 @@ export default function ControlPanel({
   };
   return (
     <div>
-      <div className="flex h-16 w-72 items-center justify-around rounded-[30px] bg-white">
+      <div className="flex h-16 w-72 items-end justify-around rounded-[30px] bg-white pb-1">
         {CONTROL_BUTTONS.map(({ id, icon, label, iconClassName }) => (
           <ControlButton
             key={id}

--- a/src/components/map/FlightProgressBar.tsx
+++ b/src/components/map/FlightProgressBar.tsx
@@ -7,13 +7,13 @@ import { useEffect, useRef, useState } from "react";
 interface Props {
   progress: number;
   setProgress: (progress: number) => void;
-  timestamp: number[];
+  allTimestamps: number[];
 }
 
 export default function FlightProgressBar({
   progress,
   setProgress,
-  timestamp,
+  allTimestamps,
 }: Props) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1); // 재생 속도 배율 (1x, 2x 등)
@@ -21,7 +21,7 @@ export default function FlightProgressBar({
 
   useEffect(() => {
     if (isPlaying) {
-      handlePlay(timestamp, progress);
+      handlePlay(allTimestamps, progress);
     }
   }, [playbackSpeed]);
 
@@ -32,7 +32,7 @@ export default function FlightProgressBar({
     if (newProgress >= 0 && newProgress <= 100) {
       if (isPlaying) {
         setProgress(newProgress);
-        handlePlay(timestamp, newProgress);
+        handlePlay(allTimestamps, newProgress);
       } else {
         setProgress(newProgress);
       }
@@ -80,15 +80,15 @@ export default function FlightProgressBar({
     }
   };
 
-  const startTime = calculateCurrentTime(timestamp, 0);
-  const endTime = calculateCurrentTime(timestamp, 100);
-  const currentTime = calculateCurrentTime(timestamp, progress);
+  const startTime = calculateCurrentTime(allTimestamps, 0);
+  const endTime = calculateCurrentTime(allTimestamps, 100);
+  const currentTime = calculateCurrentTime(allTimestamps, progress);
 
   return (
     <>
       <div>
         <div className="flex">
-          <button onClick={() => handlePlay(timestamp)}>Play</button>
+          <button onClick={() => handlePlay(allTimestamps)}>Play</button>
           <button onClick={handlePause}>Pause</button>
           <button onClick={() => setPlaybackSpeed(1)}>X1</button>
           <button onClick={() => setPlaybackSpeed(30)}>X30</button>

--- a/src/components/map/FlightProgressBar.tsx
+++ b/src/components/map/FlightProgressBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PLAY_SPEED } from "@/constants";
 import calculateCurrentTime from "@/utils/calculateCurrentTime";
 import calculateProgressByTimestamp from "@/utils/calculateProgressByTimestamp";
 import { useEffect, useRef, useState } from "react";
@@ -39,7 +40,12 @@ export default function FlightProgressBar({
     }
   };
 
-  // 재생 기능
+  // 재생
+  const togglePlay = () => {
+    setIsPlaying(!isPlaying);
+    isPlaying ? handlePause() : handlePlay(allTimestamps);
+  };
+
   const handlePlay = (
     timestamps: number[],
     currentProgress: number = progress,
@@ -86,27 +92,40 @@ export default function FlightProgressBar({
 
   return (
     <>
-      <div>
-        <div className="flex">
-          <button onClick={() => handlePlay(allTimestamps)}>Play</button>
-          <button onClick={handlePause}>Pause</button>
-          <button onClick={() => setPlaybackSpeed(1)}>X1</button>
-          <button onClick={() => setPlaybackSpeed(30)}>X30</button>
-          <div>배속: {playbackSpeed}</div>
+      <div className="flex font-bold">
+        <div className="flex w-full justify-around">
+          <span>{startTime}</span>
+          <span>{currentTime}</span>
+          <span>{endTime}</span>
         </div>
-        <div>startTime: {startTime}</div>
-        <div>endTime: {endTime}</div>
-        <div>currentTime: {currentTime}</div>
       </div>
-      <input
-        type="range"
-        min={0}
-        max="100"
-        value={progress}
-        onChange={handleInputChange}
-        className="range"
-        step="0.1"
-      />
+      <div className="flex w-full items-center gap-4">
+        <button
+          onClick={togglePlay}
+          className="size-10 flex-shrink-0 rounded-full bg-blue-500 text-white hover:bg-blue-600"
+        >
+          {isPlaying ? "❚❚" : "▶"}
+        </button>
+        <input
+          type="range"
+          min={0}
+          max="100"
+          value={progress}
+          onChange={handleInputChange}
+          className="range"
+          step="0.1"
+        />
+        <select
+          className="select select-sm w-20"
+          onChange={(e) => setPlaybackSpeed(parseFloat(e.target.value))}
+        >
+          {PLAY_SPEED.map((rate) => (
+            <option key={rate} value={rate}>
+              {rate}x
+            </option>
+          ))}
+        </select>
+      </div>
     </>
   );
 }

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -16,23 +16,22 @@ import { formatTimeString } from "@/utils/formatTimestamp";
 
 interface MapViewProps {
   progress: number;
-  selectedTimestamp: number[];
-  setSelectedTimestamp: (timestamp: number[]) => void;
+  operationTimestamps: Record<string, number[]>;
+  setOperationTimestamps: (timestamp: Record<string, number[]>) => void;
+  allTimestamps: number[];
   onMarkerClick: (id: string) => void;
 }
 
 export default function MapView({
   progress,
-  selectedTimestamp,
-  setSelectedTimestamp,
+  operationTimestamps,
+  setOperationTimestamps,
+  allTimestamps,
   onMarkerClick,
 }: MapViewProps) {
   const { telemetryData, selectedOperationId } = useData();
   const [operationLatlngs, setOperationLatlngs] = useState<
     Record<string, [number, number][]>
-  >({});
-  const [operationTimestamps, setOperationTimestamps] = useState<
-    Record<string, number[]>
   >({});
   const [dronePositions, setDronePositions] = useState<
     { flightId: string; position: [number, number]; direction: number }[]
@@ -69,15 +68,10 @@ export default function MapView({
   }, [telemetryData, selectedOperationId]);
 
   useEffect(() => {
-    const allTimestamps = Object.values(operationTimestamps).flat();
-    setSelectedTimestamp(allTimestamps.sort((a, b) => a - b));
-  }, [operationTimestamps]);
+    if (!allTimestamps || allTimestamps.length < 2) return;
 
-  useEffect(() => {
-    if (!selectedTimestamp || selectedTimestamp.length < 2) return;
-
-    const allStartTime = selectedTimestamp[0];
-    const allEndTime = selectedTimestamp[selectedTimestamp.length - 1];
+    const allStartTime = allTimestamps[0];
+    const allEndTime = allTimestamps[allTimestamps.length - 1];
     const totalDuration = allEndTime - allStartTime;
     const currentTime = allStartTime + (totalDuration * progress) / 100;
 
@@ -112,7 +106,7 @@ export default function MapView({
     });
 
     setDronePositions(updatedPositions);
-  }, [progress, selectedTimestamp, operationTimestamps, operationLatlngs]);
+  }, [progress, allTimestamps, operationTimestamps, operationLatlngs]);
 
   // 운행별 위치 데이터 반환
   const getOperationlatlings = (operationId: string) => {
@@ -270,9 +264,7 @@ export default function MapView({
               >
                 <Popup>
                   <div>
-                    <p>
-                      시간: {calculateCurrentTime(selectedTimestamp, progress)}
-                    </p>
+                    <p>시간: {calculateCurrentTime(allTimestamps, progress)}</p>
                     <p>위도: {position[0].toFixed(6)}</p>
                     <p>경도: {position[1].toFixed(6)}</p>
                     <p>방향: {Math.round(direction)}°</p>

--- a/src/components/map/SelectFlightLog.tsx
+++ b/src/components/map/SelectFlightLog.tsx
@@ -23,13 +23,19 @@ export default function SelectFlightLog({
         value={value}
       >
         <option disabled>Select Operation</option>
-        {selectedOperationId.map((id) => {
-          return (
-            <option key={id} value={id}>
-              {validOperationLabels[id]}
-            </option>
-          );
-        })}
+        {selectedOperationId
+          .sort((a, b) => {
+            const dateA = new Date(validOperationLabels[a]).getTime();
+            const dateB = new Date(validOperationLabels[b]).getTime();
+            return dateA - dateB;
+          })
+          .map((id) => {
+            return (
+              <option key={id} value={id}>
+                {validOperationLabels[id]}
+              </option>
+            );
+          })}
       </select>
     </div>
   );

--- a/src/components/map/StatusPanel.tsx
+++ b/src/components/map/StatusPanel.tsx
@@ -4,20 +4,20 @@ import { useTelemetryData } from "@/hooks/useTelemetryData";
 
 interface StatusPanelProps {
   progress: number;
-  selectedTimestamp: number[];
+  allTimestamps: number[];
   selectedOperationId: string[];
   selectedFlight: string;
 }
 
 export default function StatusPanel({
   progress,
-  selectedTimestamp,
+  allTimestamps,
   selectedOperationId,
   selectedFlight,
 }: StatusPanelProps) {
   const currentData = useTelemetryData({
     progress,
-    selectedTimestamp,
+    allTimestamps,
     selectedOperationId,
   });
 

--- a/src/components/map/StatusPanel.tsx
+++ b/src/components/map/StatusPanel.tsx
@@ -33,22 +33,6 @@ export default function StatusPanel({
     <div className="flex max-h-full w-[280px] flex-col gap-6 overflow-y-scroll rounded-[30px] bg-black py-6 pl-10 text-white opacity-80">
       <div className="flex flex-col gap-2">
         <div className="flex gap-4">
-          <img src="/images/map/icon-GPS.svg"></img>
-          <div>위치 정보</div>
-        </div>
-        <div className="flex">
-          <div className="flex-1">
-            <div>위도</div>
-            <div>{statusData?.lat}</div>
-          </div>
-          <div className="flex-1">
-            <div>경도</div>
-            <div>{statusData?.lon}</div>
-          </div>
-        </div>
-      </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-4">
           <img src="/images/map/icon-Altitude.svg" alt="Altitude" />
           <div>비행 정보</div>
         </div>
@@ -58,31 +42,41 @@ export default function StatusPanel({
             <div>{statusData?.alt}</div>
           </div>
           <div className="flex-1">
-            <div>속도</div>
-            <div>{statusData?.groundSpeed}</div>
-          </div>
-        </div>
-      </div>
-      <div className="flex flex-col gap-2">
-        <div className="flex gap-4">
-          <img src="/images/map/icon-Flight.svg" alt="Flight info" />
-          <div>기기 정보</div>
-        </div>
-        <div className="flex">
-          <div className="flex-1">
             <div>방향</div>
             <div>{statusData?.heading}</div>
-          </div>
-          <div className="flex-1">
-            <div>배터리 잔량</div>
-            <div>{statusData?.batteryRemaining}</div>
           </div>
         </div>
       </div>
       <div className="flex flex-col gap-2">
         <div className="flex gap-4">
           <img src="/images/map/icon-Accuracy.svg" alt="Accuracy" />
-          <div>기타</div>
+          <div>속도 정보</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">
+            <div>속도</div>
+            <div>{statusData?.groundSpeed}</div>
+          </div>
+          <div className="flex-1">
+            <div>총 비행 시간</div>
+            <div>{statusData?.flightTime}</div>
+          </div>
+        </div>
+      </div>
+      <div className="flex flex-col gap-2">
+        <div className="flex gap-4">
+          <img src="/images/map/icon-Flight.svg" alt="Flight info" />
+          <div>배터리 정보</div>
+        </div>
+        <div className="flex">
+          <div className="flex-1">
+            <div>온도</div>
+            <div>{statusData?.temperature}</div>
+          </div>
+          <div className="flex-1">
+            <div>배터리 잔량</div>
+            <div>{statusData?.batteryRemaining}</div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/map/StatusPanel.tsx
+++ b/src/components/map/StatusPanel.tsx
@@ -5,6 +5,7 @@ import { useTelemetryData } from "@/hooks/useTelemetryData";
 interface StatusPanelProps {
   progress: number;
   allTimestamps: number[];
+  operationTimestamps: Record<string, number[]>;
   selectedOperationId: string[];
   selectedFlight: string;
 }
@@ -12,12 +13,14 @@ interface StatusPanelProps {
 export default function StatusPanel({
   progress,
   allTimestamps,
+  operationTimestamps,
   selectedOperationId,
   selectedFlight,
 }: StatusPanelProps) {
   const currentData = useTelemetryData({
     progress,
     allTimestamps,
+    operationTimestamps,
     selectedOperationId,
   });
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,3 +44,5 @@ export const CONVERSION_FACTORS = {
   ALTITUDE: 1e-3,
   HEADING: 1e-2,
 } as const;
+
+export const PLAY_SPEED = [1, 2, 5, 10, 30];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -43,6 +43,10 @@ export const CONVERSION_FACTORS = {
   LAT_LON: 1e-7,
   ALTITUDE: 1e-3,
   HEADING: 1e-2,
+  BATTERY_REMAINING: 1e-2,
+  TEMPERATURE: 1e-2,
+  RAD_TO_DEG: 180 / Math.PI,
+  ALT_ELLIPSOID: 1e-2,
 } as const;
 
 export const PLAY_SPEED = [1, 2, 5, 10, 30];

--- a/src/hooks/useTelemetryData.ts
+++ b/src/hooks/useTelemetryData.ts
@@ -20,13 +20,13 @@ interface CombinedData {
 
 interface Props {
   progress: number;
-  selectedTimestamp: number[];
+  allTimestamps: number[];
   selectedOperationId: string[];
 }
 
 export function useTelemetryData({
   progress,
-  selectedTimestamp,
+  allTimestamps,
   selectedOperationId,
 }: Props) {
   const { telemetryData } = useData();
@@ -35,10 +35,10 @@ export function useTelemetryData({
   >([]);
 
   useEffect(() => {
-    if (!selectedTimestamp || selectedTimestamp.length === 0) return;
+    if (!allTimestamps || allTimestamps.length === 0) return;
 
-    const allStartTime = selectedTimestamp[0];
-    const allEndTime = selectedTimestamp[selectedTimestamp.length - 1];
+    const allStartTime = allTimestamps[0];
+    const allEndTime = allTimestamps[allTimestamps.length - 1];
     const totalDuration = allEndTime - allStartTime;
     const currentTime = allStartTime + (totalDuration * progress) / 100;
 
@@ -121,7 +121,7 @@ export function useTelemetryData({
     });
 
     setCurrentData(updatedStatus);
-  }, [telemetryData, progress, selectedTimestamp]);
+  }, [telemetryData, progress, allTimestamps]);
 
   const getLatestData = (
     telemetryData: { [key: string]: Telemetries[] },

--- a/src/hooks/useTelemetryData.ts
+++ b/src/hooks/useTelemetryData.ts
@@ -7,15 +7,25 @@ interface CombinedData {
   lat?: number;
   lon?: number;
   alt?: number;
-  speed?: number; // 속도
+  vx?: number;
+  vy?: number;
+  vz?: number;
   heading?: number; // 진행 방향
+  altEllipsoid?: number; // 엘리포이드 고도
+  speed?: number;
   groundSpeed?: number; // 지면 속도
+  climb?: number; // 상승 속도
   roll?: number; // 롤 각도
   pitch?: number; // 피치 각도
   yaw?: number; // 요 각도
+  rollSpeed: number;
+  pitchSpeed: number;
+  yawSpeed: number;
+  temperature?: number;
   batteryRemaining?: number; // 배터리 잔량
   energyConsumed?: number; // 소비된 에너지
   statusMessage?: string; // 상태 메시지
+  flightTime?: number; // 비행 시간
 }
 
 interface Props {
@@ -114,38 +124,60 @@ export function useTelemetryData({
         lat: latestPositionData?.payload.lat * CONVERSION_FACTORS.LAT_LON,
         lon: latestPositionData?.payload.lon * CONVERSION_FACTORS.LAT_LON,
         alt: latestPositionData?.payload.alt * CONVERSION_FACTORS.ALTITUDE,
+        vx: latestPositionData?.payload.vx,
+        vy: latestPositionData?.payload.vy,
+        vz: latestPositionData?.payload.vz,
         heading: latestPositionData?.payload.hdg * CONVERSION_FACTORS.HEADING,
-
+        altEllipsoid:
+          latestGpsData?.payload.altEllipsoid *
+          CONVERSION_FACTORS.ALT_ELLIPSOID,
         speed: latestGpsData?.payload.vel,
         groundSpeed: latestSpeedData?.payload.groundspeed,
+        climb: latestSpeedData?.payload.climb * 100,
         roll: latestAttitudeData?.payload.roll,
         pitch: latestAttitudeData?.payload.pitch,
         yaw: latestAttitudeData?.payload.yaw,
-
-        batteryRemaining: latestBatteryData?.payload.batteryRemaining,
+        rollSpeed:
+          latestAttitudeData?.payload.rollspeed * CONVERSION_FACTORS.RAD_TO_DEG,
+        pitchSpeed:
+          latestAttitudeData?.payload.pitchspeed *
+          CONVERSION_FACTORS.RAD_TO_DEG,
+        yawSpeed:
+          latestAttitudeData?.payload.yawspeed * CONVERSION_FACTORS.RAD_TO_DEG,
+        temperature:
+          latestBatteryData?.payload.temperature *
+          CONVERSION_FACTORS.TEMPERATURE,
+        batteryRemaining:
+          latestBatteryData?.payload.batteryRemaining *
+          CONVERSION_FACTORS.BATTERY_REMAINING,
         energyConsumed: latestBatteryData?.payload.energyConsumed,
         statusMessage: latestStatusData?.payload.text,
+        flightTime: operationEndTime - operationStartTime,
       };
 
       const formatData = (data: CombinedData) => ({
-        lat: `${data.lat?.toFixed(4)}°`,
-        lon: `${data.lon?.toFixed(4)}°`,
-        alt: `${data.alt?.toFixed(2)}m`,
-        heading: `${data.heading?.toFixed(2)}°`,
-        speed: `${data.speed?.toFixed(2)}m/s`,
-        groundSpeed: `${data.groundSpeed?.toFixed(2)}m/s`,
-        roll: `${data.roll?.toFixed(2)} rad`,
-        pitch: `${data.pitch?.toFixed(2)} rad`,
-        yaw: `${data.yaw?.toFixed(2)} rad`,
-        batteryRemaining:
-          data.batteryRemaining !== undefined
-            ? `${data.batteryRemaining}%`
-            : undefined,
-        energyConsumed:
-          data.energyConsumed !== undefined
-            ? `${data.energyConsumed}mWh`
-            : undefined,
+        lat: formatValue(data.lat, 4, "°"),
+        lon: formatValue(data.lon, 4, "°"),
+        alt: formatValue(data.alt, 2, "m"),
+        vx: formatValue(data.vx, 2, "m/s"),
+        vy: formatValue(data.vy, 2, "m/s"),
+        vz: formatValue(data.vz, 2, "m/s"),
+        heading: formatValue(data.heading, 2, "°"),
+        altEllipsoid: formatValue(data.altEllipsoid, 2, "m"),
+        speed: formatValue(data.speed, 2, "m/s"),
+        groundSpeed: formatValue(data.groundSpeed, 2, "m/s"),
+        climb: formatValue(data.climb, 2, " cm/s"),
+        roll: formatValue(data.roll, 2, " rad"),
+        pitch: formatValue(data.pitch, 2, " rad"),
+        yaw: formatValue(data.yaw, 2, " rad"),
+        rollSpeed: formatValue(data.rollSpeed, 4, " °/s"),
+        pitchSpeed: formatValue(data.pitchSpeed, 4, " °/s"),
+        yawSpeed: formatValue(data.yawSpeed, 4, " °/s"),
+        temperature: formatValue(data.temperature, 1, "°C"),
+        batteryRemaining: formatValue(data.batteryRemaining, 2, "%"),
+        energyConsumed: formatValue(data.energyConsumed, 0, "mWh"),
         statusMessage: data.statusMessage,
+        flightTime: formatFlightTime(data.flightTime),
       });
 
       return { flightId: id, status: formatData(mergedData) };
@@ -154,27 +186,49 @@ export function useTelemetryData({
     setCurrentData(updatedStatus);
   }, [telemetryData, progress, allTimestamps, operationTimestamps]);
 
-  const getLatestData = (
-    telemetryData: { [key: string]: Telemetries[] },
-    id: number,
-    startTime: number,
-    endTime: number,
-    currentTime: number,
-  ) => {
-    const filteredData = telemetryData[id]
-      ?.map((data) => ({
-        ...data,
-        timestamp: Date.parse(data.timestamp),
-      }))
-      .filter(
-        (data) =>
-          data.timestamp >= startTime &&
-          data.timestamp <= endTime &&
-          data.timestamp <= currentTime,
-      );
-
-    return filteredData?.[filteredData.length - 1] ?? null;
-  };
-
   return currentData;
 }
+
+const getLatestData = (
+  telemetryData: { [key: string]: Telemetries[] },
+  id: number,
+  startTime: number,
+  endTime: number,
+  currentTime: number,
+) => {
+  const filteredData = telemetryData[id]
+    ?.map((data) => ({
+      ...data,
+      timestamp: Date.parse(data.timestamp),
+    }))
+    .filter(
+      (data) =>
+        data.timestamp >= startTime &&
+        data.timestamp <= endTime &&
+        data.timestamp <= currentTime,
+    );
+
+  return filteredData?.[filteredData.length - 1] ?? null;
+};
+
+const formatValue = (
+  value: number | undefined,
+  decimals: number,
+  unit: string,
+) => {
+  if (value === undefined || isNaN(value)) return "-";
+  return `${value.toFixed(decimals)}${unit}`;
+};
+
+const formatFlightTime = (flightTime: number | undefined) => {
+  if (flightTime === undefined || isNaN(flightTime)) return "-";
+
+  const totalSeconds = flightTime / 1000;
+
+  const hours = Math.floor(totalSeconds / 3600); // 전체 초를 3600으로 나누어 시간 계산
+  const minutes = Math.floor((totalSeconds % 3600) / 60); // 남은 초에서 분 계산
+  const seconds = totalSeconds % 60; // 나머지 초 계산
+
+  // 00:00 형식으로 변환
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds.toFixed(0)).padStart(2, "0")}`;
+};

--- a/src/utils/calculateCurrentTime.ts
+++ b/src/utils/calculateCurrentTime.ts
@@ -8,5 +8,7 @@ export default function calculateCurrentTime(
   const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
   const currentTime = timestamps[0] + (totalDuration * progress) / 100;
   const result = formatTimeString(currentTime);
+  if (result === "Invalid Date") return;
+
   return result;
 }

--- a/src/utils/calculateCurrentTime.ts
+++ b/src/utils/calculateCurrentTime.ts
@@ -1,4 +1,4 @@
-import { formatTimeString } from "./formatTimestamp";
+import { formatTimestamp } from "./formatTimestamp";
 
 export default function calculateCurrentTime(
   timestamps: number[],
@@ -7,7 +7,7 @@ export default function calculateCurrentTime(
   if (!timestamps) return null;
   const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
   const currentTime = timestamps[0] + (totalDuration * progress) / 100;
-  const result = formatTimeString(currentTime);
+  const result = formatTimestamp(currentTime, "timestring");
   if (result === "Invalid Date") return;
 
   return result;

--- a/src/utils/formatTimestamp.ts
+++ b/src/utils/formatTimestamp.ts
@@ -1,26 +1,45 @@
 /**
  * ISO 8601 형식의 타임스탬프 문자열을 한국시각으로 변환
  *
- * @param {string} timestamp - ISO 8601 형식의 타임스탬프 문자열
- * @returns {string} "YYYY. MM. DD. HH:mm" 형식의 한국 시각 (유효하지 않은 타임스탬프가 전달되면 "Invalid Date" 반환)
+ * @param {string | number} timestamp - ISO 8601 형식의 타임스탬프 문자열/숫자
+ * @param {string} type - "default" 또는 "timestring"을 선택하여 출력 형식 지정
+ * @returns {string} 지정된 형식에 맞는 한국 시각 문자열
+ *   - "default" : "YYYY-MM-DD HH:mm"
+ *   - "timestring" : "HH:mm:ss"
+ *   - 유효하지 않은 타임스탬프가 전달되면 "Invalid Date" 반환
  */
 
-export function formatTimestamp(timestamp: string) {
+export function formatTimestamp(
+  timestamp: string | number,
+  type: "default" | "timestring" = "default",
+): string {
   const date = new Date(timestamp);
 
-  const formattedDate = date
-    .toLocaleString("ko-KR", {
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
+  if (type === "default") {
+    const formattedDate = date
+      .toLocaleString("ko-KR", {
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false, // 24시간 형식
+      })
+      .replace(/\//g, "-")
+      .replace(",", "");
+    return formattedDate;
+  }
+
+  if (type === "timestring") {
+    const timestring = date.toLocaleString([], {
       hour: "2-digit",
       minute: "2-digit",
-      hour12: false, // 24시간 형식
-    })
-    .replace(/\//g, "-")
-    .replace(",", "");
+      second: "2-digit",
+    });
+    return timestring;
+  }
 
-  return formattedDate;
+  return "Invalid Date"; // 예상치 못한 경우
 }
 
 export function formatTimeString(timestamp: number) {


### PR DESCRIPTION
- 사이드바에서 선택된 operation 중 우측 상단 드롭박스에서 선택한 운행의 정보가 시간별로 출력됨
    - 드롭박스 operation 목록 시간순 정렬 처리
    - 비행 데이터가 없는 시간에는 패널에 데이터 표시 안함 (운행별 시간 조건 추가)
    - StatusPanel 표기 항목 변경 : 위도/경도 제외, 고도/속도/방향/배터리정보 표기
- 재생바 디자인 작업 진행중
  - 재생/일시정지 버튼 및 배속 드롭박스 추가 
  - 사이드바에서 선택된 operation들의 시간을 통째로 계산하여 시작시간/종료시간 표시
  - 재생바 위치에 따른 현재시간 표시