### PR TITLE
[map] 재생바 타임라인 및 zoom 기능 추가

### DIFF
--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -83,12 +83,13 @@ export default function MapPage() {
             <AttitudePanel />
           </div>
         </div>
-        <div className="absolute bottom-7 left-1/2 z-10 w-2/3 min-w-80 -translate-x-1/2">
+        <div className="absolute bottom-7 left-1/2 z-10 flex w-2/3 min-w-80 -translate-x-1/2 flex-col gap-1">
           <FlightProgressBar
             progress={progress}
             setProgress={setProgress}
             allTimestamps={allTimestamps}
             operationTimestamps={operationTimestamps}
+            setSelectedFlight={setSelectedFlight}
           />
           <div className="flex justify-center">
             <ControlPanel

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -88,6 +88,7 @@ export default function MapPage() {
             progress={progress}
             setProgress={setProgress}
             allTimestamps={allTimestamps}
+            operationTimestamps={operationTimestamps}
           />
           <div className="flex justify-center">
             <ControlPanel

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -11,6 +11,7 @@ import useSidebarStore from "@/store/useSidebar";
 import useResizePanelControl from "@/hooks/useResizePanelControl";
 import SelectFlightLog from "@/components/map/SelectFlightLog";
 import useData from "@/store/useData";
+import { INITIAL_POSITION } from "@/constants";
 
 export default function MapPage() {
   const { isSidebarOpen } = useSidebarStore();
@@ -23,6 +24,12 @@ export default function MapPage() {
     Record<string, number[]>
   >({});
   const [allTimestamps, setAllTimestamps] = useState<number[]>([]);
+  const [operationStartPoint, setOperationStartPoint] =
+    useState<Record<string, [number, number]>>();
+  const [mapPosition, setMapPosition] = useState<[number, number]>([
+    INITIAL_POSITION.LAT,
+    INITIAL_POSITION.LNG,
+  ]);
 
   useEffect(() => {
     setSelectedFlight(selectedOperationId[0]);
@@ -43,7 +50,12 @@ export default function MapPage() {
   };
 
   const zoomToDrone = () => {
-    // Todo
+    if (operationStartPoint && operationStartPoint[selectedFlight]) {
+      const [lat, lng] = operationStartPoint[selectedFlight];
+      setMapPosition([lat, lng]);
+    } else {
+      console.warn(`Start point not found for ID: ${selectedFlight}`);
+    }
   };
 
   return (
@@ -61,6 +73,10 @@ export default function MapPage() {
             setOperationTimestamps={setOperationTimestamps}
             allTimestamps={allTimestamps}
             onMarkerClick={setSelectedFlight}
+            operationStartPoint={operationStartPoint}
+            setOperationStartPoint={setOperationStartPoint}
+            mapPosition={mapPosition}
+            setMapPosition={setMapPosition}
           />
         </div>
         <div className="absolute right-8 top-8 z-10 flex max-h-[90%] flex-col gap-4">

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -4,13 +4,14 @@ import Sidebar from "@/components/common/Sidebar";
 import StatusPanel from "@/components/map/StatusPanel";
 import AttitudePanel from "@/components/map/AttitudePanel";
 import FlightProgressBar from "@/components/map/FlightProgressBar";
+import SelectFlightLog from "@/components/map/SelectFlightLog";
 import MapView from "@/components/map/MapView";
 import ControlPanel from "@/components/map/ControlPanel";
 import { useEffect, useState } from "react";
+import useData from "@/store/useData";
 import useSidebarStore from "@/store/useSidebar";
 import useResizePanelControl from "@/hooks/useResizePanelControl";
-import SelectFlightLog from "@/components/map/SelectFlightLog";
-import useData from "@/store/useData";
+import useOperationData from "@/hooks/useOperationData";
 import { INITIAL_POSITION } from "@/constants";
 
 export default function MapPage() {
@@ -18,6 +19,7 @@ export default function MapPage() {
   const { isStatusOpen, setIsStatusOpen, isAttitudeOpen, setIsAttitudeOpen } =
     useResizePanelControl();
   const { selectedOperationId } = useData();
+  const { updatedTimestamps, updatedStartPoint } = useOperationData();
   const [selectedFlight, setSelectedFlight] = useState(selectedOperationId[0]);
   const [progress, setProgress] = useState(0);
   const [operationTimestamps, setOperationTimestamps] = useState<
@@ -32,14 +34,21 @@ export default function MapPage() {
   ]);
 
   useEffect(() => {
+    const sortedAllTimestamps = Object.values(updatedTimestamps)
+      .flat()
+      .sort((a, b) => a - b);
+    setOperationTimestamps(updatedTimestamps);
+    setAllTimestamps(sortedAllTimestamps);
+
+    const initialPosition = updatedStartPoint[selectedOperationId[0]];
+    setOperationStartPoint(updatedStartPoint);
+    setMapPosition(initialPosition);
+  }, [updatedTimestamps, updatedStartPoint]);
+
+  useEffect(() => {
     setSelectedFlight(selectedOperationId[0]);
     setProgress(0);
   }, [selectedOperationId]);
-
-  useEffect(() => {
-    const allTimestamps = Object.values(operationTimestamps).flat();
-    setAllTimestamps(allTimestamps.sort((a, b) => a - b));
-  }, [operationTimestamps]);
 
   const toggleStatusPanel = () => {
     setIsStatusOpen(!isStatusOpen);
@@ -70,13 +79,9 @@ export default function MapPage() {
           <MapView
             progress={progress}
             operationTimestamps={operationTimestamps}
-            setOperationTimestamps={setOperationTimestamps}
             allTimestamps={allTimestamps}
             onMarkerClick={setSelectedFlight}
-            operationStartPoint={operationStartPoint}
-            setOperationStartPoint={setOperationStartPoint}
             mapPosition={mapPosition}
-            setMapPosition={setMapPosition}
           />
         </div>
         <div className="absolute right-8 top-8 z-10 flex max-h-[90%] flex-col gap-4">

--- a/src/components/map/FlightProgressBar.tsx
+++ b/src/components/map/FlightProgressBar.tsx
@@ -4,17 +4,20 @@ import { PLAY_SPEED } from "@/constants";
 import calculateTimeByProgress from "@/utils/calculateTimeByProgress";
 import calculateProgressByTimestamp from "@/utils/calculateProgressByTimestamp";
 import { useEffect, useRef, useState } from "react";
+import Timeline from "@/components/map/Timeline";
 
 interface Props {
   progress: number;
   setProgress: (progress: number) => void;
   allTimestamps: number[];
+  operationTimestamps: Record<string, number[]>;
 }
 
 export default function FlightProgressBar({
   progress,
   setProgress,
   allTimestamps,
+  operationTimestamps,
 }: Props) {
   const [isPlaying, setIsPlaying] = useState(false);
   const [playbackSpeed, setPlaybackSpeed] = useState(1); // 재생 속도 배율 (1x, 2x 등)
@@ -103,15 +106,21 @@ export default function FlightProgressBar({
           {isPlaying ? "❚❚" : "▶"}
         </button>
         {startTime}
-        <input
-          type="range"
-          min={0}
-          max="100"
-          value={progress}
-          onChange={handleInputChange}
-          className="range"
-          step="0.1"
-        />
+        <div className="w-full">
+          <input
+            type="range"
+            min={0}
+            max="100"
+            value={progress}
+            onChange={handleInputChange}
+            className="range"
+            step="0.1"
+          />
+          <Timeline
+            allTimestamps={allTimestamps}
+            operationTimestamps={operationTimestamps}
+          />
+        </div>
         {endTime}
         <select
           className="select select-sm w-20"

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -14,7 +14,6 @@ import useData from "@/store/useData";
 import React, { useEffect, useState } from "react";
 import { getColorFromId } from "@/utils/getColorFromId";
 import { formatTimestamp } from "@/utils/formatTimestamp";
-import { INITIAL_POSITION } from "@/constants";
 
 interface MapViewProps {
   progress: number;
@@ -22,6 +21,12 @@ interface MapViewProps {
   setOperationTimestamps: (timestamp: Record<string, number[]>) => void;
   allTimestamps: number[];
   onMarkerClick: (id: string) => void;
+  operationStartPoint: Record<string, [number, number]> | undefined;
+  setOperationStartPoint: (
+    startpoints: Record<string, [number, number]>,
+  ) => void;
+  mapPosition: [number, number];
+  setMapPosition: (latlng: [number, number]) => void;
 }
 
 export default function MapView({
@@ -30,6 +35,10 @@ export default function MapView({
   setOperationTimestamps,
   allTimestamps,
   onMarkerClick,
+  operationStartPoint,
+  setOperationStartPoint,
+  mapPosition,
+  setMapPosition,
 }: MapViewProps) {
   const { telemetryData, selectedOperationId } = useData();
   const [operationLatlngs, setOperationLatlngs] = useState<
@@ -38,12 +47,6 @@ export default function MapView({
   const [dronePositions, setDronePositions] = useState<
     { flightId: string; position: [number, number]; direction: number }[]
   >([]);
-  const [operationStartPoint, setOperationStartPoint] =
-    useState<Record<string, [number, number]>>();
-  const [mapPosition, setMapPosition] = useState<[number, number]>([
-    INITIAL_POSITION.LAT,
-    INITIAL_POSITION.LNG,
-  ]);
 
   useEffect(() => {
     const updatedLatlngs = selectedOperationId.reduce(

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -13,33 +13,25 @@ import useData from "@/store/useData";
 import React, { useEffect, useState } from "react";
 import { getColorFromId } from "@/utils/getColorFromId";
 import { mapCalculator } from "@/utils/mapCalculator";
+import useOperationData from "@/hooks/useOperationData";
 
 interface MapViewProps {
   progress: number;
   operationTimestamps: Record<string, number[]>;
-  setOperationTimestamps: (timestamp: Record<string, number[]>) => void;
   allTimestamps: number[];
   onMarkerClick: (id: string) => void;
-  operationStartPoint: Record<string, [number, number]> | undefined;
-  setOperationStartPoint: (
-    startpoints: Record<string, [number, number]>,
-  ) => void;
   mapPosition: [number, number];
-  setMapPosition: (latlng: [number, number]) => void;
 }
 
 export default function MapView({
   progress,
   operationTimestamps,
-  setOperationTimestamps,
   allTimestamps,
   onMarkerClick,
-  operationStartPoint,
-  setOperationStartPoint,
   mapPosition,
-  setMapPosition,
 }: MapViewProps) {
-  const { telemetryData, selectedOperationId } = useData();
+  const { selectedOperationId } = useData();
+  const { updatedLatlngs } = useOperationData();
   const [operationLatlngs, setOperationLatlngs] = useState<
     Record<string, [number, number][]>
   >({});
@@ -48,50 +40,8 @@ export default function MapView({
   >([]);
 
   useEffect(() => {
-    const positionData = telemetryData[33] || [];
-
-    const updatedLatlngs = selectedOperationId.reduce(
-      (acc, id) => {
-        const latlngs = mapCalculator.getOperationlatlings(id, positionData);
-        if (latlngs.length > 0) {
-          acc[id] = latlngs;
-        }
-        return acc;
-      },
-      {} as Record<string, [number, number][]>,
-    );
-
-    const updatedTimestamps = selectedOperationId.reduce(
-      (acc, id) => {
-        const rawTimestamps = mapCalculator.getOperationTimes(id, positionData);
-        const timestamps = rawTimestamps.map((timestamp) =>
-          Date.parse(timestamp),
-        );
-        if (timestamps.length > 0) {
-          acc[id] = timestamps;
-        }
-        return acc;
-      },
-      {} as Record<string, number[]>,
-    );
-
-    const updatedStartPoint = selectedOperationId.reduce(
-      (acc, id) => {
-        const startPoint = updatedLatlngs[id][0];
-        acc[id] = startPoint;
-        return acc;
-      },
-      {} as Record<string, [number, number]>,
-    );
-
-    if (operationStartPoint) {
-      setMapPosition(updatedStartPoint[selectedOperationId[0]]);
-    }
-
     setOperationLatlngs(updatedLatlngs);
-    setOperationTimestamps(updatedTimestamps);
-    setOperationStartPoint(updatedStartPoint);
-  }, [telemetryData, selectedOperationId]);
+  }, [updatedLatlngs]);
 
   useEffect(() => {
     if (!allTimestamps || allTimestamps.length < 2) return;

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -9,11 +9,10 @@ import {
   useMap,
 } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
-import L from "leaflet";
 import useData from "@/store/useData";
 import React, { useEffect, useState } from "react";
 import { getColorFromId } from "@/utils/getColorFromId";
-import { formatTimestamp } from "@/utils/formatTimestamp";
+import { mapCalculator } from "@/utils/mapCalculator";
 
 interface MapViewProps {
   progress: number;
@@ -49,9 +48,11 @@ export default function MapView({
   >([]);
 
   useEffect(() => {
+    const positionData = telemetryData[33] || [];
+
     const updatedLatlngs = selectedOperationId.reduce(
       (acc, id) => {
-        const latlngs = getOperationlatlings(id);
+        const latlngs = mapCalculator.getOperationlatlings(id, positionData);
         if (latlngs.length > 0) {
           acc[id] = latlngs;
         }
@@ -62,7 +63,7 @@ export default function MapView({
 
     const updatedTimestamps = selectedOperationId.reduce(
       (acc, id) => {
-        const rawTimestamps = getOperationTimes(id);
+        const rawTimestamps = mapCalculator.getOperationTimes(id, positionData);
         const timestamps = rawTimestamps.map((timestamp) =>
           Date.parse(timestamp),
         );
@@ -119,12 +120,12 @@ export default function MapView({
         const operationProgress =
           ((currentTime - startTime) / (endTime - startTime)) * 100;
 
-        const position = calculateDronePosition(
+        const position = mapCalculator.calculateDronePosition(
           operationProgress,
           positions,
           timestamps,
         );
-        const direction = calculateDirection(
+        const direction = mapCalculator.calculateDirection(
           operationProgress,
           positions,
           timestamps,
@@ -143,125 +144,6 @@ export default function MapView({
 
     setDronePositions(updatedPositions);
   }, [progress, allTimestamps, operationTimestamps, operationLatlngs]);
-
-  // 운행별 위치 데이터 반환
-  const getOperationlatlings = (operationId: string) => {
-    const positionData = telemetryData[33] || [];
-    const result = positionData
-      .filter((data) => data.operation === operationId)
-      .map((data) => {
-        const lat = data.payload.lat * 1e-7;
-        const lon = data.payload.lon * 1e-7;
-        return [lat, lon];
-      });
-    return result as [number, number][];
-  };
-
-  // 운행별 시간 데이터 반환
-  const getOperationTimes = (operationId: string) => {
-    const positionData = telemetryData[33] || [];
-    const result = positionData
-      .filter((data) => data.operation === operationId)
-      .map((data) => data.timestamp);
-    return result;
-  };
-
-  // 시간별 위치 데이터 계산
-  const calculateDronePosition = (
-    progress: number,
-    positions: [number, number][],
-    timestamps: number[],
-  ): [number, number] => {
-    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
-    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
-    const index = timestamps.findIndex((timestamp) => timestamp >= currentTime);
-
-    if (index === -1) {
-      return positions[positions.length - 1];
-    }
-    if (index === 0) {
-      return positions[0];
-    }
-
-    // 현재 시간에 대한 위치 계산 (선형 보간)
-    const t0 = timestamps[index - 1];
-    const t1 = timestamps[index];
-    const ratio = (currentTime - t0) / (t1 - t0);
-
-    const pos0 = positions[index - 1];
-    const pos1 = positions[index];
-
-    return [
-      pos0[0] + (pos1[0] - pos0[0]) * ratio,
-      pos0[1] + (pos1[1] - pos0[1]) * ratio,
-    ];
-  };
-
-  // 방향 계산
-  const calculateDirection = (
-    progress: number,
-    positions: [number, number][],
-    timestamps: number[],
-  ) => {
-    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
-    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
-
-    let index = -1;
-    for (let i = 0; i < timestamps.length - 1; i++) {
-      if (currentTime >= timestamps[i] && currentTime <= timestamps[i + 1]) {
-        index = i;
-        break;
-      }
-    }
-
-    if (index === -1) {
-      return 0;
-    }
-    if (index === 0) {
-      return 0;
-    }
-
-    const t0 = timestamps[index];
-    const t1 = timestamps[index + 1];
-    const pos0 = positions[index];
-    const pos1 = positions[index + 1];
-
-    // 방향 계산: 두 위치 간의 방향 각도 계산
-    const deltaY = pos1[0] - pos0[0];
-    const deltaX = pos1[1] - pos0[1];
-    const bearing = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
-    const droneHeading = (90 - bearing) % 360;
-
-    return droneHeading < 0 ? droneHeading + 360 : droneHeading;
-  };
-
-  // 아이콘 생성
-  const createRotatedIcon = (rotationAngle: number) =>
-    L.divIcon({
-      className: "",
-      html: `
-        <div 
-          style="
-            width: 30px; 
-            height: 30px; 
-            background: url('/images/map/marker-icon.png') no-repeat center/contain; 
-            transform: rotate(${rotationAngle}deg);
-            transition: transform 0.3s ease;
-          ">
-        </div>
-      `,
-      iconSize: [30, 30],
-      iconAnchor: [15, 15],
-    });
-
-  // 진행도별 시간 계산
-  const calculateCurrentTime = (timestamps: number[], progress: number) => {
-    if (!timestamps) return null;
-    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
-    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
-    const result = formatTimestamp(currentTime, "timestring");
-    return result;
-  };
 
   return (
     <div className="relative z-0 h-full w-full">
@@ -296,11 +178,17 @@ export default function MapView({
               <Marker
                 key={flightId}
                 position={position}
-                icon={createRotatedIcon(direction)}
+                icon={mapCalculator.createRotatedIcon(direction)}
               >
                 <Popup>
                   <div>
-                    <p>시간: {calculateCurrentTime(allTimestamps, progress)}</p>
+                    <p>
+                      시간:{" "}
+                      {mapCalculator.calculateCurrentTime(
+                        allTimestamps,
+                        progress,
+                      )}
+                    </p>
                     <p>위도: {position[0].toFixed(4)}</p>
                     <p>경도: {position[1].toFixed(4)}</p>
                   </div>

--- a/src/components/map/StatusPanel.tsx
+++ b/src/components/map/StatusPanel.tsx
@@ -39,11 +39,11 @@ export default function StatusPanel({
         <div className="flex">
           <div className="flex-1">
             <div>고도</div>
-            <div>{statusData?.alt}</div>
+            <div>{statusData?.alt ?? "-"}</div>
           </div>
           <div className="flex-1">
             <div>방향</div>
-            <div>{statusData?.heading}</div>
+            <div>{statusData?.heading ?? "-"}</div>
           </div>
         </div>
       </div>
@@ -55,11 +55,11 @@ export default function StatusPanel({
         <div className="flex">
           <div className="flex-1">
             <div>속도</div>
-            <div>{statusData?.groundSpeed}</div>
+            <div>{statusData?.groundSpeed ?? "-"}</div>
           </div>
           <div className="flex-1">
             <div>비행 시간</div>
-            <div>{statusData?.flightTime}</div>
+            <div>{statusData?.flightTime ?? "-"}</div>
           </div>
         </div>
       </div>
@@ -71,11 +71,11 @@ export default function StatusPanel({
         <div className="flex">
           <div className="flex-1">
             <div>온도</div>
-            <div>{statusData?.temperature}</div>
+            <div>{statusData?.temperature ?? "-"}</div>
           </div>
           <div className="flex-1">
             <div>배터리 잔량</div>
-            <div>{statusData?.batteryRemaining}</div>
+            <div>{statusData?.batteryRemaining ?? "-"}</div>
           </div>
         </div>
       </div>

--- a/src/components/map/Timeline.tsx
+++ b/src/components/map/Timeline.tsx
@@ -1,0 +1,79 @@
+import { getColorFromId } from "@/utils/getColorFromId";
+
+interface Props {
+  allTimestamps: number[];
+  operationTimestamps: Record<string, number[]>;
+}
+
+export default function Timeline({
+  allTimestamps,
+  operationTimestamps,
+}: Props) {
+  const startTimestamp = allTimestamps[0];
+  const endTimestamp = allTimestamps[allTimestamps.length - 1];
+  const totalDuration = endTimestamp - startTimestamp;
+
+  const timelineData = calculateTimelineData(operationTimestamps);
+  const maxLayer = Math.max(...timelineData.map((op) => op.layer));
+
+  function calculateTimelineData(
+    operationTimestamps: Record<string, number[]>,
+  ) {
+    const timelineData = Object.entries(operationTimestamps).map(
+      ([id, timestamps]) => {
+        const start = Math.min(...timestamps);
+        const end = Math.max(...timestamps);
+        return { id, start, end };
+      },
+    );
+
+    return setLayers(timelineData);
+  }
+
+  function setLayers(
+    timelineData: { id: string; start: number; end: number }[],
+  ) {
+    const layers: number[] = []; // 각 층의 가장 최근 end값을 저장
+
+    return timelineData.map((operation) => {
+      const layerIndex = layers.findIndex(
+        (endTime) => operation.start >= endTime,
+      );
+
+      // 사용할 수 있는 층이 없으면 새 층 추가, 있으면 기존 층에 배치
+      if (layerIndex === -1) {
+        layers.push(operation.end);
+        return { ...operation, layer: layers.length - 1 };
+      } else {
+        layers[layerIndex] = operation.end;
+        return { ...operation, layer: layerIndex };
+      }
+    });
+  }
+
+  return (
+    <div
+      className="relative w-full overflow-x-clip"
+      style={{ height: `${maxLayer + 1}px` }}
+    >
+      {timelineData.map((operation) => {
+        const startPercent =
+          ((operation.start - startTimestamp) / totalDuration) * 100;
+        const endPercent =
+          ((operation.end - startTimestamp) / totalDuration) * 100;
+        return (
+          <div
+            key={operation.id}
+            className="absolute h-1 rounded-full"
+            style={{
+              left: `${startPercent}%`,
+              width: `${endPercent - startPercent}%`,
+              top: `${operation.layer}px`,
+              backgroundColor: `${getColorFromId(operation.id)}`,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/map/Timeline.tsx
+++ b/src/components/map/Timeline.tsx
@@ -1,6 +1,7 @@
 import { TIMELINE } from "@/constants";
 import { getTimelineStyles } from "@/utils/getTimelineStyles";
 import { TimelineData } from "@/types/types";
+import { timelineCaculator } from "@/utils/timelineCalculator";
 
 interface Props {
   allTimestamps: number[];
@@ -17,44 +18,9 @@ export default function Timeline({
   const endTimestamp = allTimestamps[allTimestamps.length - 1];
   const totalDuration = endTimestamp - startTimestamp;
 
-  const timelineData = calculateTimelineData(operationTimestamps);
+  const timelineData = timelineCaculator.calculateData(operationTimestamps);
   const maxLayer = Math.max(...timelineData.map((op) => op.layer));
   const maxLayerHeight = (maxLayer + 1) * (TIMELINE.HEIGHT + TIMELINE.GAP);
-
-  function calculateTimelineData(
-    operationTimestamps: Record<string, number[]>,
-  ) {
-    const timelineData = Object.entries(operationTimestamps).map(
-      ([id, timestamps]) => {
-        const start = Math.min(...timestamps);
-        const end = Math.max(...timestamps);
-        return { id, start, end };
-      },
-    );
-
-    return setLayers(timelineData);
-  }
-
-  function setLayers(
-    timelineData: { id: string; start: number; end: number }[],
-  ) {
-    const layers: number[] = []; // 각 층의 가장 최근 end값을 저장
-
-    return timelineData.map((operation) => {
-      const layerIndex = layers.findIndex(
-        (endTime) => operation.start >= endTime,
-      );
-
-      // 사용할 수 있는 층이 없으면 새 층 추가, 있으면 기존 층에 배치
-      if (layerIndex === -1) {
-        layers.push(operation.end);
-        return { ...operation, layer: layers.length - 1 };
-      } else {
-        layers[layerIndex] = operation.end;
-        return { ...operation, layer: layerIndex };
-      }
-    });
-  }
 
   return (
     <div

--- a/src/components/map/Timeline.tsx
+++ b/src/components/map/Timeline.tsx
@@ -1,6 +1,6 @@
-import { TIMELINE_HEIGHT } from "@/constants";
+import { TIMELINE } from "@/constants";
+import { getTimelineStyles } from "@/utils/getTimelineStyles";
 import { TimelineData } from "@/types/types";
-import { getColorFromId } from "@/utils/getColorFromId";
 
 interface Props {
   allTimestamps: number[];
@@ -19,7 +19,7 @@ export default function Timeline({
 
   const timelineData = calculateTimelineData(operationTimestamps);
   const maxLayer = Math.max(...timelineData.map((op) => op.layer));
-  const maxLayerHeight = (maxLayer + 1) * TIMELINE_HEIGHT;
+  const maxLayerHeight = (maxLayer + 1) * (TIMELINE.HEIGHT + TIMELINE.GAP);
 
   function calculateTimelineData(
     operationTimestamps: Record<string, number[]>,
@@ -62,21 +62,16 @@ export default function Timeline({
       style={{ height: `${maxLayerHeight}px` }}
     >
       {timelineData.map((operation) => {
-        const startPercent =
-          ((operation.start - startTimestamp) / totalDuration) * 100;
-        const endPercent =
-          ((operation.end - startTimestamp) / totalDuration) * 100;
+        const styles = getTimelineStyles(
+          operation,
+          startTimestamp,
+          totalDuration,
+        );
         return (
           <div
             key={operation.id}
             className="absolute h-1 cursor-pointer rounded-full"
-            style={{
-              left: `${startPercent}%`,
-              width: `${endPercent - startPercent}%`,
-              top: `${operation.layer}px`,
-              height: `${TIMELINE_HEIGHT}px`,
-              backgroundColor: `${getColorFromId(operation.id)}`,
-            }}
+            style={styles}
             onClick={() => onTimelineClick(operation.id, timelineData)}
           />
         );

--- a/src/components/map/Timeline.tsx
+++ b/src/components/map/Timeline.tsx
@@ -1,3 +1,4 @@
+import { TIMELINE_HEIGHT } from "@/constants";
 import { TimelineData } from "@/types/types";
 import { getColorFromId } from "@/utils/getColorFromId";
 
@@ -18,6 +19,7 @@ export default function Timeline({
 
   const timelineData = calculateTimelineData(operationTimestamps);
   const maxLayer = Math.max(...timelineData.map((op) => op.layer));
+  const maxLayerHeight = (maxLayer + 1) * TIMELINE_HEIGHT;
 
   function calculateTimelineData(
     operationTimestamps: Record<string, number[]>,
@@ -57,7 +59,7 @@ export default function Timeline({
   return (
     <div
       className="relative w-full overflow-x-clip"
-      style={{ height: `${maxLayer + 1}px` }}
+      style={{ height: `${maxLayerHeight}px` }}
     >
       {timelineData.map((operation) => {
         const startPercent =
@@ -72,6 +74,7 @@ export default function Timeline({
               left: `${startPercent}%`,
               width: `${endPercent - startPercent}%`,
               top: `${operation.layer}px`,
+              height: `${TIMELINE_HEIGHT}px`,
               backgroundColor: `${getColorFromId(operation.id)}`,
             }}
             onClick={() => onTimelineClick(operation.id, timelineData)}

--- a/src/components/map/Timeline.tsx
+++ b/src/components/map/Timeline.tsx
@@ -1,13 +1,16 @@
+import { TimelineData } from "@/types/types";
 import { getColorFromId } from "@/utils/getColorFromId";
 
 interface Props {
   allTimestamps: number[];
   operationTimestamps: Record<string, number[]>;
+  onTimelineClick: (id: string, timelineData: TimelineData[]) => void;
 }
 
 export default function Timeline({
   allTimestamps,
   operationTimestamps,
+  onTimelineClick,
 }: Props) {
   const startTimestamp = allTimestamps[0];
   const endTimestamp = allTimestamps[allTimestamps.length - 1];
@@ -64,13 +67,14 @@ export default function Timeline({
         return (
           <div
             key={operation.id}
-            className="absolute h-1 rounded-full"
+            className="absolute h-1 cursor-pointer rounded-full"
             style={{
               left: `${startPercent}%`,
               width: `${endPercent - startPercent}%`,
               top: `${operation.layer}px`,
               backgroundColor: `${getColorFromId(operation.id)}`,
             }}
+            onClick={() => onTimelineClick(operation.id, timelineData)}
           />
         );
       })}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -50,3 +50,5 @@ export const CONVERSION_FACTORS = {
 } as const;
 
 export const PLAY_SPEED = [1, 2, 5, 10, 30];
+
+export const TIMELINE_HEIGHT = 4;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,3 +52,5 @@ export const CONVERSION_FACTORS = {
 export const PLAY_SPEED = [1, 2, 5, 10, 30];
 
 export const TIMELINE_HEIGHT = 4;
+
+export const INITIAL_POSITION = { LAT: 37.566381, LNG: 126.977717 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -51,6 +51,9 @@ export const CONVERSION_FACTORS = {
 
 export const PLAY_SPEED = [1, 2, 5, 10, 30];
 
-export const TIMELINE_HEIGHT = 4;
+export const TIMELINE = {
+  HEIGHT: 4,
+  GAP: 1,
+} as const;
 
 export const INITIAL_POSITION = { LAT: 37.566381, LNG: 126.977717 } as const;

--- a/src/hooks/useDronePosition.ts
+++ b/src/hooks/useDronePosition.ts
@@ -1,0 +1,63 @@
+import useData from "@/store/useData";
+import { mapCalculator } from "@/utils/mapCalculator";
+import { useMemo } from "react";
+
+export default function useDronePosition(
+  progress: number,
+  allTimestamps: number[],
+  operationTimestamps: Record<string, number[]>,
+  operationLatlngs: Record<string, [number, number][]>,
+) {
+  const { selectedOperationId } = useData();
+  return useMemo(() => {
+    if (!allTimestamps || allTimestamps.length < 2) return [];
+
+    const allStartTime = allTimestamps[0];
+    const allEndTime = allTimestamps[allTimestamps.length - 1];
+    const totalDuration = allEndTime - allStartTime;
+    const currentTime = allStartTime + (totalDuration * progress) / 100;
+
+    // 운행별 마커 위치 계산
+    const updatedPositions = selectedOperationId.map((id) => {
+      const timestamps = operationTimestamps[id] || [];
+      const positions = operationLatlngs[id] || [];
+
+      const startTime = timestamps[0];
+      const endTime = timestamps[timestamps.length - 1];
+
+      // 운행 시작 전
+      if (currentTime < startTime) {
+        return { flightId: id, position: positions[0], direction: 0 };
+      }
+
+      // 운행 중
+      if (currentTime >= startTime && currentTime <= endTime) {
+        // 개별 진행률 계산
+        const operationProgress =
+          ((currentTime - startTime) / (endTime - startTime)) * 100;
+
+        const position = mapCalculator.calculateDronePosition(
+          operationProgress,
+          positions,
+          timestamps,
+        );
+        const direction = mapCalculator.calculateDirection(
+          operationProgress,
+          positions,
+          timestamps,
+        );
+
+        return { flightId: id, position, direction };
+      }
+
+      // 운행 종료 후
+      return {
+        flightId: id,
+        position: positions[positions.length - 1],
+        direction: 0,
+      };
+    });
+
+    return updatedPositions;
+  }, [progress, allTimestamps, operationTimestamps, operationLatlngs]);
+}

--- a/src/hooks/useOperationData.ts
+++ b/src/hooks/useOperationData.ts
@@ -1,0 +1,55 @@
+import useData from "@/store/useData";
+import { mapCalculator } from "@/utils/mapCalculator";
+import { useMemo } from "react";
+
+export default function useOperationData() {
+  const { telemetryData, selectedOperationId } = useData();
+  return useMemo(() => {
+    const positionData = telemetryData[33] || [];
+
+    const updatedLatlngs = selectedOperationId.reduce(
+      (acc, id) => {
+        const latlngs = mapCalculator.getOperationlatlings(id, positionData);
+        if (latlngs.length > 0) {
+          acc[id] = latlngs;
+        }
+        return acc;
+      },
+      {} as Record<string, [number, number][]>,
+    );
+
+    const updatedTimestamps = selectedOperationId.reduce(
+      (acc, id) => {
+        const rawTimestamps = mapCalculator.getOperationTimes(id, positionData);
+        const timestamps = rawTimestamps.map((timestamp) =>
+          Date.parse(timestamp),
+        );
+        if (timestamps.length > 0) {
+          acc[id] = timestamps;
+        }
+        return acc;
+      },
+      {} as Record<string, number[]>,
+    );
+
+    const updatedStartPoint = selectedOperationId.reduce(
+      (acc, id) => {
+        const startPoint = mapCalculator.getOperationStartPoint(
+          id,
+          positionData,
+        );
+        if (startPoint) {
+          acc[id] = startPoint;
+        }
+        return acc;
+      },
+      {} as Record<string, [number, number]>,
+    );
+
+    return {
+      updatedLatlngs,
+      updatedTimestamps,
+      updatedStartPoint,
+    };
+  }, [telemetryData, selectedOperationId]);
+}

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -1,0 +1,114 @@
+import { TimelineData } from "@/types/types";
+import calculateProgressByTimestamp from "@/utils/calculateProgressByTimestamp";
+import { useEffect, useRef, useState } from "react";
+
+export default function usePlayback(
+  allTimestamps: number[],
+  progress: number,
+  setProgress: (progress: number) => void,
+) {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [playbackSpeed, setPlaybackSpeed] = useState(1);
+  const intervalId = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    if (isPlaying) {
+      handlePlay(allTimestamps, progress);
+    }
+  }, [playbackSpeed]);
+
+  const handlePlay = (
+    timestamps: number[],
+    currentProgress: number = progress,
+  ) => {
+    if (!timestamps || timestamps.length === 0) return;
+
+    if (intervalId.current) {
+      clearInterval(intervalId.current);
+      setIsPlaying(false);
+    }
+
+    setIsPlaying(true);
+    const startTime =
+      timestamps[0] +
+      ((timestamps[timestamps.length - 1] - timestamps[0]) * currentProgress) /
+        100;
+    let startPlaybackTime = Date.now();
+
+    intervalId.current = setInterval(() => {
+      const elapsedTime = (Date.now() - startPlaybackTime) * playbackSpeed;
+      const newTime = startTime + elapsedTime;
+
+      const newProgress = calculateProgressByTimestamp(timestamps, newTime);
+      setProgress(newProgress);
+
+      if (newProgress >= 100) {
+        clearInterval(intervalId.current!);
+        setIsPlaying(false);
+        setProgress(0);
+      }
+    }, 100); // 업데이트 간격 (100ms)
+  };
+
+  const handlePause = () => {
+    if (intervalId.current) {
+      clearInterval(intervalId.current);
+      setIsPlaying(false);
+    }
+  };
+
+  const togglePlay = () => {
+    isPlaying ? handlePause() : handlePlay(allTimestamps);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newProgress = Number(event.target.value);
+
+    if (newProgress >= 0 && newProgress <= 100) {
+      if (isPlaying) {
+        setProgress(newProgress);
+        handlePlay(allTimestamps, newProgress);
+      } else {
+        setProgress(newProgress);
+      }
+    }
+  };
+
+  const handleTimelineClick = (
+    id: string,
+    timelineData: TimelineData[],
+    setSelectedFlight: (id: string) => void,
+  ) => {
+    const operation = timelineData.find((operation) => operation.id === id);
+    const startTime = operation?.start ?? 0;
+    const endTime = operation?.end ?? 0;
+    const startPoint = calculateProgressByTimestamp(allTimestamps, startTime);
+    const endPoint = calculateProgressByTimestamp(allTimestamps, endTime);
+
+    // 선택한 operation의 비행시간인 경우, 패널만 변경
+    if (progress >= startPoint && progress <= endPoint) {
+      setSelectedFlight(id);
+      return;
+    }
+
+    // 선택한 operation의 비행시간이 아닌 경우, 재생바 이동 및 패널 변경
+    if (isPlaying) {
+      setSelectedFlight(id);
+      setProgress(startPoint);
+      handlePlay(allTimestamps, startPoint);
+    } else {
+      setSelectedFlight(id);
+      setProgress(startPoint);
+    }
+  };
+
+  return {
+    progress,
+    setProgress,
+    isPlaying,
+    setPlaybackSpeed,
+    togglePlay,
+    handleInputChange,
+    handleTimelineClick,
+  };
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,0 +1,6 @@
+export interface TimelineData {
+  layer: number;
+  id: string;
+  start: number;
+  end: number;
+}

--- a/src/utils/getTimelineStyles.ts
+++ b/src/utils/getTimelineStyles.ts
@@ -1,0 +1,25 @@
+import { TIMELINE } from "@/constants";
+import { getColorFromId } from "@/utils/getColorFromId";
+
+export const getTimelineStyles = (
+  operation: {
+    layer: number;
+    id: string;
+    start: number;
+    end: number;
+  },
+  startTimestamp: number,
+  totalDuration: number,
+) => {
+  const startPercent =
+    ((operation.start - startTimestamp) / totalDuration) * 100;
+  const endPercent = ((operation.end - startTimestamp) / totalDuration) * 100;
+
+  return {
+    left: `${startPercent}%`,
+    width: `${endPercent - startPercent}%`,
+    top: `${operation.layer * (TIMELINE.HEIGHT + TIMELINE.GAP)}px`,
+    height: `${TIMELINE.HEIGHT}px`,
+    backgroundColor: getColorFromId(operation.id),
+  };
+};

--- a/src/utils/mapCalculator.ts
+++ b/src/utils/mapCalculator.ts
@@ -1,0 +1,121 @@
+import { Telemetries } from "@/types/api";
+import L from "leaflet";
+import { formatTimestamp } from "@/utils/formatTimestamp";
+
+export const mapCalculator = {
+  // 운행별 위치 데이터 반환
+  getOperationlatlings(operationId: string, positionData: Telemetries[]) {
+    const result = positionData
+      .filter((data) => data.operation === operationId)
+      .map((data) => {
+        const lat = data.payload.lat * 1e-7;
+        const lon = data.payload.lon * 1e-7;
+        return [lat, lon];
+      });
+    return result as [number, number][];
+  },
+
+  // 운행별 시간 데이터 반환
+  getOperationTimes(operationId: string, positionData: Telemetries[]) {
+    const result = positionData
+      .filter((data) => data.operation === operationId)
+      .map((data) => data.timestamp);
+    return result;
+  },
+
+  // 시간별 위치 데이터 계산
+  calculateDronePosition(
+    progress: number,
+    positions: [number, number][],
+    timestamps: number[],
+  ): [number, number] {
+    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
+    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
+    const index = timestamps.findIndex((timestamp) => timestamp >= currentTime);
+
+    if (index === -1) {
+      return positions[positions.length - 1];
+    }
+    if (index === 0) {
+      return positions[0];
+    }
+
+    // 현재 시간에 대한 위치 계산 (선형 보간)
+    const t0 = timestamps[index - 1];
+    const t1 = timestamps[index];
+    const ratio = (currentTime - t0) / (t1 - t0);
+
+    const pos0 = positions[index - 1];
+    const pos1 = positions[index];
+
+    return [
+      pos0[0] + (pos1[0] - pos0[0]) * ratio,
+      pos0[1] + (pos1[1] - pos0[1]) * ratio,
+    ];
+  },
+
+  // 방향 계산
+  calculateDirection(
+    progress: number,
+    positions: [number, number][],
+    timestamps: number[],
+  ) {
+    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
+    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
+
+    let index = -1;
+    for (let i = 0; i < timestamps.length - 1; i++) {
+      if (currentTime >= timestamps[i] && currentTime <= timestamps[i + 1]) {
+        index = i;
+        break;
+      }
+    }
+
+    if (index === -1) {
+      return 0;
+    }
+    if (index === 0) {
+      return 0;
+    }
+
+    const pos0 = positions[index];
+    const pos1 = positions[index + 1];
+
+    // 방향 계산: 두 위치 간의 방향 각도 계산
+    const deltaY = pos1[0] - pos0[0];
+    const deltaX = pos1[1] - pos0[1];
+    const bearing = (Math.atan2(deltaY, deltaX) * 180) / Math.PI;
+    const droneHeading = (90 - bearing) % 360;
+
+    return droneHeading < 0 ? droneHeading + 360 : droneHeading;
+  },
+
+  // 아이콘 생성
+  createRotatedIcon(rotationAngle: number) {
+    return L.divIcon({
+      className: "",
+      html: `
+            <div 
+              style="
+                width: 30px; 
+                height: 30px; 
+                background: url('/images/map/marker-icon.png') no-repeat center/contain; 
+                transform: rotate(${rotationAngle}deg);
+                transition: transform 0.3s ease;
+              ">
+            </div>
+          `,
+      iconSize: [30, 30],
+      iconAnchor: [15, 15],
+    });
+  },
+
+  // 진행도별 시간 계산
+  calculateCurrentTime(timestamps: number[], progress: number) {
+    if (!timestamps) return null;
+    const totalDuration = timestamps[timestamps.length - 1] - timestamps[0];
+    const currentTime = timestamps[0] + (totalDuration * progress) / 100;
+    const result = formatTimestamp(currentTime, "timestring");
+    return result;
+  },
+};

--- a/src/utils/mapCalculator.ts
+++ b/src/utils/mapCalculator.ts
@@ -23,6 +23,16 @@ export const mapCalculator = {
     return result;
   },
 
+  // 운행별 시작 위치 반환
+  getOperationStartPoint(operationId: string, positionData: Telemetries[]) {
+    const data = positionData.find((data) => data.operation === operationId);
+    if (!data) return null;
+
+    const lat = data.payload.lat * 1e-7;
+    const lon = data.payload.lon * 1e-7;
+    return [lat, lon] as [number, number];
+  },
+
   // 시간별 위치 데이터 계산
   calculateDronePosition(
     progress: number,

--- a/src/utils/timelineCalculator.ts
+++ b/src/utils/timelineCalculator.ts
@@ -1,0 +1,36 @@
+interface timelineData {
+  id: string;
+  start: number;
+  end: number;
+}
+
+export const timelineCaculator = {
+  calculateData(operationTimestamps: Record<string, number[]>) {
+    const timelineData = this.convertToTimelineOperations(operationTimestamps);
+    return this.assignLayers(timelineData);
+  },
+
+  convertToTimelineOperations(operationTimestamps: Record<string, number[]>) {
+    return Object.entries(operationTimestamps).map(([id, timestamps]) => ({
+      id,
+      start: Math.min(...timestamps),
+      end: Math.max(...timestamps),
+    }));
+  },
+
+  assignLayers(timelineData: timelineData[]) {
+    const layers: number[] = []; // 각 층의 가장 최근 end값을 저장
+
+    return timelineData.map((operation) => {
+      const layer = this.findAvailableLayer(operation.start, layers);
+      layers[layer] = operation.end;
+      return { ...operation, layer };
+    });
+  },
+
+  // 사용할 수 있는 층이 없으면 새 층 추가, 있으면 기존 층에 배치
+  findAvailableLayer(start: number, layers: number[]) {
+    const existingLayer = layers.findIndex((endTime) => start >= endTime);
+    return existingLayer === -1 ? layers.length : existingLayer;
+  },
+};


### PR DESCRIPTION
1. 재생바 타임라인 추가
    - 재생바 하단에 operation별 운행시간을 표시하는 타임라인 추가
        - operation 별 고유색으로 표현
        - 중복시간이 있을 경우, 아래줄에 표시되도록 하였으나 250127 기준 샘플데이터에는 해당 케이스의 데이터가 없어 추후 확인 필요
    - 타임라인 클릭 시 해당 비행으로 이동
        - StatusPanel 비행 변경 (selectedFlight)
        - 선택된 비행 시작시간으로 이동 (재생바) 
        
2. zoom 기능 추가
    - 지도 최초 로딩 시 operation이 선택되어 있지 않음
    - 사이드바에서 operation 체크 시, 해당 operation의 시작 위치로 이동 (경로 생성과 동시에 이동)
    - 복수의 operation 체크 시, 선택된 operation 중 가장 빠른 운행 기준으로 이동
    - 컨트롤 패널에서 zoom 버튼 클릭 시, selectedFlight의 시작 위치로 이동
    
3. map 페이지 내 계산 로직 분리 
    - 타임라인 계산 로직 분리 (getTimelineStyles, timelineCalculator, 함수 모음)
    - MapView 계산 로직 분리 (mapCalculator, 함수 모음)
    - operation 데이터 계산 로직 분리 (useOperationData, 훅)
    - 드론위치 계산 로직 분리 (useDronePosition, 훅)
    - 재생 제어 로직 분리 (usePlayback, 훅)