### PR TITLE
[common] 사용자가 선택한 로봇 데이터만 받아오도록 개선 

### DIFF
--- a/src/app/(data)/map/page.tsx
+++ b/src/app/(data)/map/page.tsx
@@ -1,13 +1,18 @@
 "use client";
 
+import dynamic from "next/dynamic";
 import StatusPanel from "@/components/map/StatusPanel";
 import AttitudePanel from "@/components/map/AttitudePanel";
 import FlightProgressBar from "@/components/map/FlightProgressBar";
-import MapView from "@/components/map/MapView";
 import ControlPanel from "@/components/map/ControlPanel";
 import { useState } from "react";
 import useResizePanelControl from "@/hooks/useResizePanelControl";
 import SelectFlightLog from "@/components/map/SelectFlightLog";
+
+const MapView = dynamic(() => import("@/components/map/MapView"), {
+  ssr: false,
+  loading: () => <div>Loading map...</div>,
+}); // 500오류 수정:  "window is not defined" SSR
 
 export default function MapPage() {
   const { isStatusOpen, setIsStatusOpen, isAttitudeOpen, setIsAttitudeOpen } =

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -14,8 +14,8 @@ export default function Sidebar() {
     telemetryData,
     validOperationLabels,
     setValidOperationLabel,
-    setSelectedOperation,
     toggleSelectedOperation,
+    selectedOperationId,
   } = useData();
   const positionData = telemetryData[33] || [];
 
@@ -39,7 +39,6 @@ export default function Sidebar() {
     }, {});
 
     setValidOperationLabel(validOperationLabel);
-    setSelectedOperation(validOperationLabel);
   }, [operationData, telemetryData]);
 
   const robotIds = [...new Set(operationData.map((value) => value["robot"]))];
@@ -88,7 +87,9 @@ export default function Sidebar() {
                         <label className="flex cursor-pointer items-center gap-3">
                           <input
                             type="checkbox"
-                            defaultChecked
+                            checked={selectedOperationId.includes(
+                              operation._id,
+                            )}
                             className="checkbox checkbox-sm"
                             onChange={() =>
                               toggleSelectedOperation(operation._id)

--- a/src/lib/dbService.ts
+++ b/src/lib/dbService.ts
@@ -1,4 +1,5 @@
 import { connectDB } from "@/lib/database";
+import { ObjectId } from "mongodb";
 
 // 조건 설정 가능 ; query = { msgId: 30 }
 export async function fetchCollection(
@@ -8,6 +9,14 @@ export async function fetchCollection(
   const client = await connectDB;
   const db = client.db("data");
   const collection = db.collection(collectionName);
+
+  if (query.operation) {
+    try {
+      query.operation = new ObjectId(query.operation);
+    } catch (error) {
+      console.warn("Invalid ObjectId format for operation:", query.operation);
+    }
+  }
 
   Object.keys(query).forEach((key) => {
     if (!isNaN(Number(query[key]))) {

--- a/src/store/useData.ts
+++ b/src/store/useData.ts
@@ -1,5 +1,5 @@
 import { fetchData } from "@/lib/fetchClient";
-import { create } from "zustand";
+import { create, useStore } from "zustand";
 import { Robot, Operation, Telemetries } from "@/types/api";
 
 interface DataState {
@@ -10,7 +10,7 @@ interface DataState {
   fetchRobotData: () => Promise<void>;
 
   telemetryData: { [key: string]: Telemetries[] };
-  fetchTelemetryData: () => Promise<void>;
+  fetchTelemetryData: (operationIds?: string[]) => Promise<void>;
 
   validOperationLabels: Record<string, string>;
   setValidOperationLabel: (labels: Record<string, string>) => void;
@@ -20,7 +20,7 @@ interface DataState {
   toggleSelectedOperation: (operationId: string) => void;
 }
 
-const useData = create<DataState>((set) => ({
+const useData = create<DataState>((set, get) => ({
   operationData: [],
   fetchOperationData: async () => {
     const result = await fetchData("operations");
@@ -34,30 +34,49 @@ const useData = create<DataState>((set) => ({
   },
 
   telemetryData: {},
-  fetchTelemetryData: async (operationId) => {
-    // 이미 불러온 데이터인지 확인 (캐시)
-    if (get().telemetryData[operationId]) return;
+  fetchTelemetryData: async (operationIds?: string[]) => {
+    const selectedOperations = operationIds || get().selectedOperationId;
 
-    const result = await fetchData("telemetries", { operation: operationId });
+    if (selectedOperations.length === 0) {
+      set({ telemetryData: {} });
 
-    // msgId별로 데이터를 그룹화
-    const categorizedData = filteredData.reduce(
-      (acc: { [key: string]: Telemetries[] }, data: Telemetries) => {
-        const { msgId } = data;
+      return;
+    }
 
-        if (!acc[msgId]) {
-          acc[msgId] = [];
-        }
-        acc[msgId].push(data);
+    const promises = selectedOperations.map(async (operationId) => {
+      try {
+        const data = await fetchData(`telemetries`, { operation: operationId });
+        return data;
+      } catch (error) {
+        console.error(
+          `오퍼레이션을 불러오는데 실패했습니다. ${operationId}:`,
+          error,
+        );
+        return [];
+      }
+    });
 
-        return acc;
-      },
-      {},
-    );
+    try {
+      const results = await Promise.all(promises);
+      const allTelemetries = results.flat();
 
-    set((state) => ({
-      telemetryData: { ...state.telemetryData, [operationId]: categorizedData },
-    }));
+      const categorizedData = allTelemetries.reduce(
+        (acc: { [key: string]: Telemetries[] }, data: Telemetries) => {
+          const { msgId } = data;
+          if (!acc[msgId]) {
+            acc[msgId] = [];
+          }
+          acc[msgId].push(data);
+          return acc;
+        },
+        {},
+      );
+
+      set({ telemetryData: categorizedData });
+    } catch (error) {
+      console.error("텔레메트리를 불러오는데 실패했습니다.", error);
+      set({ telemetryData: {} });
+    }
   },
 
   validOperationLabels: {},
@@ -69,21 +88,25 @@ const useData = create<DataState>((set) => ({
   setSelectedOperation: (operations) => {
     const formattedData = Object.keys(operations);
     set({ selectedOperationId: formattedData });
-
-    get().fetchTelemetryData();
+    // 새로 선택된 operation들의 데이터만 불러오기
+    get().fetchTelemetryData(formattedData);
   },
   toggleSelectedOperation: async (operationId) => {
     set((state) => {
       const selectedOperationsSet = new Set(state.selectedOperationId);
 
-      selectedOperationsSet.has(operationId)
-        ? selectedOperationsSet.delete(operationId)
-        : selectedOperationsSet.add(operationId);
+      if (selectedOperationsSet.has(operationId)) {
+        selectedOperationsSet.delete(operationId);
+      } else {
+        selectedOperationsSet.add(operationId);
+      }
 
-      return { selectedOperationId: [...selectedOperationsSet] };
+      const newSelectedOperations = [...selectedOperationsSet];
+      // 토글된 후의 operation 목록으로 데이터 불러오기
+      get().fetchTelemetryData(newSelectedOperations);
+
+      return { selectedOperationId: newSelectedOperations };
     });
-    // 체크할 때만 텔레메트리 데이터 요청
-    await get().fetchTelemetryData(operationId);
   },
 }));
 


### PR DESCRIPTION
[다른 팀원 분이 작성하신 코드](https://github.com/ormcamp-fe-3rd/FlightLog/pull/26)의 기능에 수정이 필요하여 추가 작업을 하였습니다. 1주차 코드 리뷰 때 익환 님께서 PR 살펴보셨던 코드입니다!
MongoDB를 사용 중이며, Auth.js 외에 백엔드 관련 별도 라이브러리를 사용하고 있지는 않습니다.


<br>



# 주요 기능
전체 데이터를 먼저 로드하지 않고, 사용자가 사이드 바에서 체크 박스를 눌러 요청한 데이터만 필터링하여 호출합니다.

<br>



## 히스토리 
1. 해당 코드의 초기 버전은, 요청에 관계없이 map페이지 진입시 모든 데이터를 한 번에 받아왔습니다
2. 데이터가 많아질수록, 로딩 속도도 늘어나는 구조라 개선이 필요했습니다. 
3. 첫 홈페이지에 진입하면서 데이터를 받도록 수정했지만 근본적인 해결은 아니었습니다.
4. 사용자 요청(체크 박스 토글)에 맞는 필요 데이터만 불러오도록 수정하여 현재 상태가 됐습니다.

<br>


## 개선해야 하는 부분 
- 체크 박스 우측의 시간은 드론(M?_?호기)가 비행을 시작한 시점인데요, 데이터를 받아야 라벨로 지정되는 상태입니다.
- 체크 박스를 누르지 않으면 데이터를 받지 않는 로직으로 변했기때문에, 체크 박스를 눌러야만 라벨이 표시되는 문제가 있습니다.
- 아주 소량의 데이터만 먼저 받아와서 라벨에 추가할 수 있도록 추가할 예정입니다.
- 현재 개선한 코드도 첫 데이터 로드에는 개별 데이터의 크기에 따라 1초 내외로 걸리는 상황이라 조금 더 빨라졌으면 하는 바람이 좀 있습니다.

<br>


↓ 개선 전, 모든 데이터를 맵페이지 진입시 한 번에 받아오는 모습
![2025-01-28 00 24 56](https://github.com/user-attachments/assets/b5b4f922-d2ef-443f-ae9e-2c809e43fe72)


↓ 개선 작업 진행 중의 모습, 체크 박스를 클릭한 시점에 데이터를 받아오도록 수정 / 체크 박스 라벨 수정 예정
![2025-01-28 00 26 12](https://github.com/user-attachments/assets/86ec3f6b-0ec7-45dc-8fa4-9b15f38c288b)

