### PR TITLE
[사이드바, map] 버그 수정 1차

### DIFF
--- a/src/app/(data)/map/page.tsx
+++ b/src/app/(data)/map/page.tsx
@@ -17,15 +17,12 @@ export default function MapPage() {
   const { isSidebarOpen } = useSidebarStore();
   const { isStatusOpen, setIsStatusOpen, isAttitudeOpen, setIsAttitudeOpen } =
     useResizePanelControl();
-  const { selectedOperationId } = useData();
+  const { selectedOperationId, setAllTimestamps, setOperationTimestamps } =
+    useData();
   const { updatedTimestamps, updatedStartPoint } = useOperationData();
   const [selectedFlight, setSelectedFlight] = useState(selectedOperationId[0]);
   const [progress, setProgress] = useState(0);
-  const [operationTimestamps, setOperationTimestamps] = useState<
-    Record<string, number[]>
-  >({});
   const [isPlaying, setIsPlaying] = useState(false);
-  const [allTimestamps, setAllTimestamps] = useState<number[]>([]);
   const [dronePositions, setDronePositions] = useState<
     { flightId: string; position: [number, number]; direction: number }[]
   >([]);
@@ -78,8 +75,6 @@ export default function MapPage() {
         <div className="h-full w-full">
           <MapView
             progress={progress}
-            operationTimestamps={operationTimestamps}
-            allTimestamps={allTimestamps}
             onMarkerClick={setSelectedFlight}
             mapPosition={mapPosition}
             dronePositions={dronePositions}
@@ -94,20 +89,11 @@ export default function MapPage() {
           <div
             className={`${isStatusOpen ? "block" : "hidden"} overflow-hidden overflow-y-auto rounded-[30px]`}
           >
-            <StatusPanel
-              progress={progress}
-              allTimestamps={allTimestamps}
-              operationTimestamps={operationTimestamps}
-              selectedOperationId={selectedOperationId}
-              selectedFlight={selectedFlight}
-            />
+            <StatusPanel progress={progress} selectedFlight={selectedFlight} />
           </div>
           <div className={`${isAttitudeOpen ? "block" : "hidden"}`}>
             <AttitudePanel
               progress={progress}
-              allTimestamps={allTimestamps}
-              operationTimestamps={operationTimestamps}
-              selectedOperationId={selectedOperationId}
               selectedFlight={selectedFlight}
               isPlaying={isPlaying}
             />
@@ -117,8 +103,6 @@ export default function MapPage() {
           <FlightProgressBar
             progress={progress}
             setProgress={setProgress}
-            allTimestamps={allTimestamps}
-            operationTimestamps={operationTimestamps}
             setSelectedFlight={setSelectedFlight}
             setIsPlaying={setIsPlaying}
           />

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { formatTimestamp } from "@/utils/formatTimestamp";
 import useData from "@/store/useData";
-import { PAGES } from "@/constants";
+import { MAX_DURATION, PAGES } from "@/constants";
 import findOperationStartTime from "@/utils/findOperationStartTime";
 import { getColorFromId } from "@/utils/getColorFromId";
+import calculateTotalTimeGap from "@/utils/calculateTotalTimeGap";
 
 export default function Sidebar() {
   const {
@@ -17,6 +18,7 @@ export default function Sidebar() {
     setValidOperationLabel,
     toggleSelectedOperation,
     selectedOperationId,
+    allTimestamps,
   } = useData();
   const positionData = telemetryData[33] || [];
 
@@ -124,6 +126,15 @@ export default function Sidebar() {
     });
   };
 
+  const totalDuration = calculateTotalTimeGap(allTimestamps);
+  const durationLabel = totalDuration?.formattedTime ?? "00:00:00";
+  const isDurationExceeded =
+    totalDuration && totalDuration.milliseconds > MAX_DURATION.MILLISECONDS;
+  const warningStyle = isDurationExceeded ? "text-red-600" : "";
+  const dataTip = isDurationExceeded
+    ? `총 재생 시간이 ${MAX_DURATION.HOURS}시간을 초과했습니다. 타임라인이나 그래프에서 공백이 길게 보일 수 있습니다.`
+    : "총 재생 시간";
+
   return (
     <aside className="flex h-[calc(100vh-56px)] w-72 flex-col gap-5 border-r bg-white p-4 text-lg">
       <div className="flex flex-col gap-5">
@@ -140,7 +151,14 @@ export default function Sidebar() {
       <hr className="border-[#D9D9D9]" />
       {!isLoading ? (
         <div className="flex flex-col gap-5">
-          <h2 className="font-bold">Operations</h2>
+          <div className="flex items-center gap-4">
+            <h2 className="font-bold">Operations</h2>
+            <div className="tooltip" data-tip={dataTip}>
+              <button className={`btn btn-outline btn-sm ${warningStyle}`}>
+                {durationLabel}
+              </button>
+            </div>
+          </div>
           {robotIds.map((robotId) => {
             return (
               <div

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -160,7 +160,7 @@ export default function Sidebar() {
                     if (operation["robot"] === robotId) {
                       return (
                         <div key={operation._id} className="flex flex-col py-1">
-                          <label className="flex h-6 cursor-pointer items-center gap-3">
+                          <label className="relative flex h-6 cursor-pointer items-center gap-3">
                             <input
                               type="checkbox"
                               checked={selectedOperationId.includes(
@@ -188,9 +188,8 @@ export default function Sidebar() {
                                 )}
                               </span>
                             )}
-                            {/* 컬러 라벨 */}
                             <span
-                              className="size-2 rounded-full"
+                              className="absolute right-1 size-2 rounded-full"
                               style={{
                                 backgroundColor: getColorFromId(operation._id),
                               }}

--- a/src/components/map/AttitudePanel.tsx
+++ b/src/components/map/AttitudePanel.tsx
@@ -8,12 +8,10 @@ import { useEffect, useRef, useState } from "react";
 import { useAttitudeData } from "@/hooks/useAttitudeData";
 import { CameraControls, Html, PerspectiveCamera } from "@react-three/drei";
 import isFlightActive from "@/utils/isFlightActive";
+import useData from "@/store/useData";
 
 interface AttitudePanelProps {
   progress: number;
-  allTimestamps: number[];
-  operationTimestamps: Record<string, number[]>;
-  selectedOperationId: string[];
   selectedFlight: string;
   isPlaying: boolean;
 }
@@ -34,12 +32,10 @@ const CANVAS_CONFIG = {
 
 export default function AttitudePanel({
   progress,
-  allTimestamps,
-  operationTimestamps,
-  selectedOperationId,
   selectedFlight,
   isPlaying,
 }: AttitudePanelProps) {
+  const { allTimestamps, operationTimestamps, selectedOperationId } = useData();
   const [isActive, setIsActive] = useState(false);
 
   useEffect(() => {

--- a/src/components/map/FlightProgressBar.tsx
+++ b/src/components/map/FlightProgressBar.tsx
@@ -6,12 +6,11 @@ import Timeline from "@/components/map/Timeline";
 import usePlayback from "@/hooks/usePlayback";
 import { TimelineData } from "@/types/types";
 import { useEffect } from "react";
+import useData from "@/store/useData";
 
 interface Props {
   progress: number;
   setProgress: (progress: number) => void;
-  allTimestamps: number[];
-  operationTimestamps: Record<string, number[]>;
   setSelectedFlight: (id: string) => void;
   setIsPlaying: (isPlaying: boolean) => void;
 }
@@ -19,11 +18,10 @@ interface Props {
 export default function FlightProgressBar({
   progress,
   setProgress,
-  allTimestamps,
-  operationTimestamps,
   setSelectedFlight,
   setIsPlaying,
 }: Props) {
+  const { allTimestamps, operationTimestamps } = useData();
   const {
     isPlaying,
     togglePlay,

--- a/src/components/map/MapView.tsx
+++ b/src/components/map/MapView.tsx
@@ -19,8 +19,6 @@ import { DronePosition } from "@/types/types";
 
 interface MapViewProps {
   progress: number;
-  operationTimestamps: Record<string, number[]>;
-  allTimestamps: number[];
   onMarkerClick: (id: string) => void;
   mapPosition: [number, number];
   dronePositions: DronePosition[];
@@ -29,14 +27,12 @@ interface MapViewProps {
 
 export default function MapView({
   progress,
-  operationTimestamps,
-  allTimestamps,
   onMarkerClick,
   mapPosition,
   dronePositions,
   setDronePositions,
 }: MapViewProps) {
-  const { selectedOperationId } = useData();
+  const { selectedOperationId, allTimestamps, operationTimestamps } = useData();
   const { updatedLatlngs } = useOperationData();
   const [operationLatlngs, setOperationLatlngs] = useState<
     Record<string, [number, number][]>

--- a/src/components/map/StatusPanel.tsx
+++ b/src/components/map/StatusPanel.tsx
@@ -1,22 +1,18 @@
 "use client";
 
 import { useStatusData } from "@/hooks/useStatusData";
+import useData from "@/store/useData";
 
 interface StatusPanelProps {
   progress: number;
-  allTimestamps: number[];
-  operationTimestamps: Record<string, number[]>;
-  selectedOperationId: string[];
   selectedFlight: string;
 }
 
 export default function StatusPanel({
   progress,
-  allTimestamps,
-  operationTimestamps,
-  selectedOperationId,
   selectedFlight,
 }: StatusPanelProps) {
+  const { allTimestamps, operationTimestamps, selectedOperationId } = useData();
   const currentData = useStatusData({
     progress,
     allTimestamps,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -57,3 +57,8 @@ export const TIMELINE = {
 } as const;
 
 export const INITIAL_POSITION = { LAT: 37.566381, LNG: 126.977717 } as const;
+
+export const MAX_DURATION = {
+  HOURS: 24,
+  MILLISECONDS: 24 * 60 * 60 * 1000,
+} as const;

--- a/src/store/useData.ts
+++ b/src/store/useData.ts
@@ -19,6 +19,12 @@ interface DataState {
   setSelectedOperation: (operations: Record<string, string>) => void;
   toggleSelectedOperation: (operationId: string) => void;
   fetchInitialTelemetries: () => Promise<void>;
+
+  allTimestamps: number[];
+  setAllTimestamps: (timestamps: number[]) => void;
+
+  operationTimestamps: Record<string, number[]>;
+  setOperationTimestamps: (timestamps: Record<string, number[]>) => void;
 }
 
 const useData = create<DataState>((set, get) => ({
@@ -154,6 +160,16 @@ const useData = create<DataState>((set, get) => ({
     } catch (error) {
       console.error("운행 시간 데이터를 불러오는데 실패했습니다.", error);
     }
+  },
+
+  allTimestamps: [],
+  setAllTimestamps: (timestamps) => {
+    set({ allTimestamps: timestamps });
+  },
+
+  operationTimestamps: {},
+  setOperationTimestamps: (timestamps) => {
+    set({ operationTimestamps: timestamps });
   },
 }));
 

--- a/src/utils/calculateTotalTimeGap.ts
+++ b/src/utils/calculateTotalTimeGap.ts
@@ -1,0 +1,22 @@
+export default function calculateTotalTimeGap(allTimestamps: number[]) {
+  if (allTimestamps.length === 0) return;
+
+  const startTimestamp = allTimestamps[0];
+  const endTimestamp = allTimestamps[allTimestamps.length - 1];
+  const totalDuration = endTimestamp - startTimestamp;
+
+  const totalSeconds = Math.floor(totalDuration / 1000);
+  const seconds = totalSeconds % 60;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  const minutes = totalMinutes % 60;
+  const totalHours = Math.floor(totalMinutes / 60);
+  const hours = totalHours % 24;
+  const days = Math.floor(totalHours / 24);
+
+  const formattedTime = `${String(totalHours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+
+  return {
+    milliseconds: totalDuration,
+    formattedTime: formattedTime,
+  };
+}


### PR DESCRIPTION
- [x] 사이드바 컬러칩 위치가 라벨 길이에 영향을 받아 정렬이 깨지는 현상 수정
- [x] 선택된 operation의 시간차이가 긴 경우, 전체 재생시간이 길어져 타임라인이 점처럼 보이는 현상 보완
    - 전체 재생시간이 너무 길어지는 케이스는 지난 회의에서 체크박스 선택을 막지 않는 것으로 의견이 모였었기 때문에 사용자에게 안내하는 방식으로 보완 
    - log 페이지에서도 같은 케이스에 대해 경고가 필요하여 사이드바에 총 재생시간을 추가함
    - 총 재생시간이 기준시간 이상인 경우, 빨간색으로 표시, 마우스 호버 시 안내문구 추가
    - allTimestamps 변수 공유가 필요해져 map page에서 정의된 상태를 전역 상태로 이동함