### PR TITLE
[map] 빌드 오류 수정(leaflet)

### DIFF
--- a/src/app/(data)/map/page.tsx
+++ b/src/app/(data)/map/page.tsx
@@ -1,17 +1,23 @@
 "use client";
 
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
 import StatusPanel from "@/components/map/StatusPanel";
 import AttitudePanel from "@/components/map/AttitudePanel";
 import FlightProgressBar from "@/components/map/FlightProgressBar";
 import SelectFlightLog from "@/components/map/SelectFlightLog";
-import MapView from "@/components/map/MapView";
 import ControlPanel from "@/components/map/ControlPanel";
-import { useEffect, useState } from "react";
 import useData from "@/store/useData";
 import useSidebarStore from "@/store/useSidebar";
 import useResizePanelControl from "@/hooks/useResizePanelControl";
 import useOperationData from "@/hooks/useOperationData";
 import { INITIAL_POSITION } from "@/constants";
+
+// 모든 브라우저 의존성 컴포넌트를 동적 임포트로 변경 (빌드 오류 수정)
+const MapView = dynamic(() => import("@/components/map/MapView"), {
+  ssr: false,
+  loading: () => <div>Loading map...</div>,
+});
 
 export default function MapPage() {
   const { isSidebarOpen } = useSidebarStore();

--- a/src/utils/mapCalculator.ts
+++ b/src/utils/mapCalculator.ts
@@ -1,5 +1,5 @@
 import { Telemetries } from "@/types/api";
-import L from "leaflet";
+const L = typeof window !== "undefined" ? require("leaflet") : null;
 import { formatTimestamp } from "@/utils/formatTimestamp";
 
 export const mapCalculator = {


### PR DESCRIPTION
# PR 내용 
map 페이지에서 빌드 오류가 수정하던 것을 고쳤습니다. 

# 원인
Leaflet 라이브러리는 브라우저 전용 도구인데, Next.js가 서버에서 이 도구를 사용하려고 해서 'window is not defined' 오류가 났습니다.

# 해결
### 1.  react-leaflet를 사용 중인 MapView.tsx를 이를 불러올 때 ``ssr: false`` 처리가 필요했습니다.
기존: ``import MapView from "@/components/map/MapView";``
변경: ``const MapView = dynamic(() => import("@/components/map/MapView"), {
 ssr: false, ...`` 
 
- 불러오면서 서버 사이드 렌더링 금지를 걸고 서버가 HTML 생성 시 이 컴포넌트를 완전히 무시하도록 했습니다.(브라우저에서만 JavaScript 번들에 포함)
 
### 2. mapCalculator.ts 검증 추가
 기존: ``import L from "leaflet";``
 변경: `const L = typeof window !== "undefined" ? require("leaflet") : null;`
 
기존 방식으로 import하면 서버에서 무조건 실행하게 되어 있고, 서버에서 즉시 window 접근을 시도하는 것으로 보입니다.
typeof window로 narrowing해서 Leaflet 라이브러리를 클라이언트 환경에서만 불러오도록 처리했습니다.


 