### PR TITLE
[map, 사이드바] 반응형 디자인 수정

### DIFF
--- a/src/app/(data)/layout.tsx
+++ b/src/app/(data)/layout.tsx
@@ -2,22 +2,35 @@
 
 import Sidebar from "@/components/common/Sidebar";
 import useSidebarStore from "@/store/useSidebar";
+import { useRef } from "react";
 
 export default function DataLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { isSidebarOpen } = useSidebarStore();
+  const { isSidebarOpen, toggle } = useSidebarStore();
+  const sidebarRef = useRef<HTMLDivElement>(null);
+
+  const handleOutsideClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (!isSidebarOpen) return;
+    if (sidebarRef.current && sidebarRef.current.contains(e.target as Node))
+      return;
+
+    toggle();
+  };
 
   return (
     <div className="flex h-[calc(100vh-56px)] overflow-hidden">
       <div
-        className={`${isSidebarOpen ? "md:block" : "md:hidden"} z-20 md:absolute`}
+        ref={sidebarRef}
+        className={`${isSidebarOpen ? "lg:block" : "lg:hidden"} z-20 lg:absolute`}
       >
         <Sidebar />
       </div>
-      {children}
+      <div className="flex-1 overflow-auto" onClick={handleOutsideClick}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/src/app/(data)/map/page.tsx
+++ b/src/app/(data)/map/page.tsx
@@ -110,7 +110,7 @@ export default function MapPage() {
             />
           </div>
         </div>
-        <div className="absolute bottom-7 left-1/2 z-10 flex w-2/3 min-w-80 -translate-x-1/2 flex-col gap-1">
+        <div className="absolute bottom-7 left-1/2 z-10 flex w-11/12 min-w-80 max-w-[800px] -translate-x-1/2 flex-col gap-1">
           <FlightProgressBar
             progress={progress}
             setProgress={setProgress}

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
   return (
     <header className="flex h-14 items-center justify-between bg-black p-4 text-white">
       <div className="flex items-center gap-5">
-        <button className="hidden size-5 md:block" onClick={toggle}>
+        <button className="hidden size-5 lg:block" onClick={toggle}>
           <img src="/images/common/icon-menu.svg" alt="Toggle sidebar" />
         </button>
         <Link href="/" className="cursor-pointer text-2xl font-bold">

--- a/src/components/map/FlightProgressBar.tsx
+++ b/src/components/map/FlightProgressBar.tsx
@@ -59,8 +59,11 @@ export default function FlightProgressBar({
 
   return (
     <>
-      <div className="flex w-full justify-around font-bold">
+      <div className="flex w-full items-end justify-around font-bold md:flex-col md:items-start md:pl-14">
         <span>{currentTime ? `현재 시간: ${currentTime}` : ""}</span>
+        <div className="hidden md:flex">
+          {startTime && endTime ? `재생 시간: ${startTime} - ${endTime}` : ""}
+        </div>
       </div>
       <div className="flex w-full items-center gap-4 font-bold">
         <button
@@ -69,7 +72,7 @@ export default function FlightProgressBar({
         >
           {isPlaying ? "❚❚" : "▶"}
         </button>
-        {startTime}
+        <span className="md:hidden">{startTime}</span>
         <div className="w-full">
           <input
             type="range"
@@ -87,7 +90,7 @@ export default function FlightProgressBar({
             onTimelineClick={handleTimelineClick}
           />
         </div>
-        {endTime}
+        <span className="md:hidden">{endTime}</span>
         <select
           className="select select-sm w-20"
           onChange={(e) => setPlaybackSpeed(parseFloat(e.target.value))}

--- a/src/hooks/useResizePanelControl.ts
+++ b/src/hooks/useResizePanelControl.ts
@@ -3,21 +3,20 @@ import useSidebarStore from "@/store/useSidebar";
 import { useEffect, useState } from "react";
 
 export default function useResizePanelControl() {
-  const { close, open } = useSidebarStore();
+  const { open } = useSidebarStore();
   const [isStatusOpen, setIsStatusOpen] = useState(true);
   const [isAttitudeOpen, setIsAttitudeOpen] = useState(true);
 
   const handleResize = () => {
-    const isDesktop = window.innerWidth > BREAKPOINTS.TABLET;
+    const isDesktop = window.innerWidth > BREAKPOINTS.DESKTOP;
     if (!isDesktop) {
-      close();
       setIsStatusOpen(false);
       setIsAttitudeOpen(false);
     } else {
-      open();
       setIsStatusOpen(true);
       setIsAttitudeOpen(true);
     }
+    open();
   };
 
   useEffect(() => {
@@ -27,7 +26,7 @@ export default function useResizePanelControl() {
     return () => {
       window.removeEventListener("resize", handleResize);
     };
-  }, [close, open]);
+  }, [open]);
 
   return {
     isStatusOpen,

--- a/src/store/useSidebar.ts
+++ b/src/store/useSidebar.ts
@@ -8,7 +8,7 @@ interface SidebarState {
 }
 
 const useSidebarStore = create<SidebarState>((set) => ({
-  isSidebarOpen: false,
+  isSidebarOpen: true,
   open: () => set(() => ({ isSidebarOpen: true })),
   close: () => set(() => ({ isSidebarOpen: false })),
   toggle: () =>


### PR DESCRIPTION
- 사이드바 햄버거 메뉴 노출 기준을 태블릿(744px) 이하에서 데스크탑(1024px) 이하로 수정 
    - 햄버거 메뉴 노출 시 사이드바가 화면 위를 덮는 형태로 위치함
    - 사이드바 외부 영역 클릭 시, 사이드바가 닫히도록 이벤트 추가
- 태블릿 사이즈 이하에서 map 재생바 레이아웃 수정: width, 시간 레이블 위치
    - 가장 작은 태블릿 사이즈에서 재생바가 너무 작게 보이는 상황 개선